### PR TITLE
Switch the Gopkg.toml to use branch instead of version for now

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "github.com/Azure/azure-pipeline-go"
   packages = ["pipeline"]
-  revision = "f4da77e3846319876aebb41f2e6dccc6b1d7f1e0"
-  version = "1.1.3"
+  revision = "9804b770d6810999e2bcb7480fb509504e72b2ba"
+  version = "0.1.4"
 
 [[projects]]
   branch = "v1"
@@ -16,6 +16,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0a0067b54adaf72c0e68dfb59225c7879de5863ff0c951e115e009ad3ecbe7bf"
+  inputs-digest = "31410b00fb3923035bcfdfb37ad828c04e176bd86f7367b5f8df9548e5cc93a2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,7 +1,7 @@
 # Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
 [[constraint]]
   name = "github.com/Azure/azure-pipeline-go"
-  version = "1.1.3"
+  branch = "master"
 
 [[constraint]]
   name = "gopkg.in/check.v1"  # This project is only needed if you run "go test" on the Azure Storage packages


### PR DESCRIPTION
Fixes #20 - uses the latest commit from `master` in the `azure-pipeline-go` repository instead.

NB: this should be switched to normal version patterns once https://github.com/Azure/azure-pipeline-go/issues/9 is figured out.