### PR TITLE
Fix "unknown field MinimumLevelToLog" error

### DIFF
--- a/2016-05-31/azblob/zt_examples_test.go
+++ b/2016-05-31/azblob/zt_examples_test.go
@@ -143,7 +143,9 @@ func ExampleNewPipeline() {
 				// This method is not called for filtered-out severities.
 				logger.Output(2, m) // This example uses Go's standard logger
 			},
-			MinimumLevelToLog: func() pipeline.LogLevel { return pipeline.LogInfo }, // Log all events from informational to more severe
+			ShouldLog: func(level pipeline.LogLevel) bool {
+				return level <= pipeline.LogInfo // Log all events from informational to more severe
+			},
 		},
 	}
 


### PR DESCRIPTION
MinimumLevelToLog has been removed in azure-pipeline-go v0.1.8.
Now replaced by ShouldLog.

```
Testing: "/builddir/build/BUILD/azure-storage-blob-go-0.2.0/_build/src/github.com/Azure/azure-storage-blob-go/2016-05-31/azblob"
+ GOPATH=/builddir/build/BUILD/azure-storage-blob-go-0.2.0/_build:/usr/share/gocode
+ go test -buildmode pie -compiler gc -ldflags '-extldflags '\''-Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld '\'''
# github.com/Azure/azure-storage-blob-go/2016-05-31/azblob [github.com/Azure/azure-storage-blob-go/2016-05-31/azblob.test]
./zt_examples_test.go:146:4: unknown field 'MinimumLevelToLog' in struct literal of type pipeline.LogOptions
FAIL	github.com/Azure/azure-storage-blob-go/2016-05-31/azblob [build failed]
```

Tested on Fedora Rawhide.