### PR TITLE
Fix off by one error in UploadStreamToBlockBlob

### DIFF
--- a/azblob/highlevel.go
+++ b/azblob/highlevel.go
@@ -407,7 +407,7 @@ func (t *uploadStreamToBlockBlobOptions) start(ctx context.Context) (interface{}
 }
 
 func (t *uploadStreamToBlockBlobOptions) chunk(ctx context.Context, num uint32, buffer []byte) error {
-	if num == 0 && len(buffer) < t.o.BufferSize {
+	if num == 0 && len(buffer) <= t.o.BufferSize {
 		// If whole payload fits in 1 block, don't stage it; End will upload it with 1 I/O operation
 		t.firstBlock = buffer
 		return nil


### PR DESCRIPTION
Before this fix, if you tried to upload a single part blob with
UploadStreamToBlockBlob of exactly BufferSize you would get this
error:

===== RESPONSE ERROR (ServiceCode=Md5Mismatch) =====
Description=The MD5 value specified in the request did not match with the MD5 value calculated by the server.
RequestId:5bca9423-f01e-003f-550d-632dc8000000
Time:2018-10-13T15:55:57.7806913Z, Details:
   Code: Md5Mismatch
   ServerCalculatedMd5: 1B2M2Y8AsgTpgAmY7PhCfg==
   UserSpecifiedMd5: DzQ7CTESaiDxM9Z8KwGKOw==

This is caused by the uploadStreamToBlockBlobOptions.chunk() calculating
that more than one block was needed in this case.