### PR TITLE
build: fix canonical path for golint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH ${GOPATH}/bin:$PATH
 ENV ACCOUNT_NAME ${ACCOUNT_NAME}
 ENV ACCOUNT_KEY ${ACCOUNT_KEY}
 RUN go get -u github.com/golang/dep/cmd/dep
-RUN go get -u github.com/golang/lint/golint
+RUN go get -u golang.org/x/lint/golint
 RUN go get -u github.com/mitchellh/gox
 
 


### PR DESCRIPTION
This stops the build erroring with

package github.com/golang/lint/golint: code in directory /go/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint