### PR TITLE
Docs: update stdout for upload example

### DIFF
--- a/azblob/zt_examples_test.go
+++ b/azblob/zt_examples_test.go
@@ -941,7 +941,7 @@ func Example_progressUploadDownload() {
 	// Wrap the request body in a RequestBodyProgress and pass a callback function for progress reporting.
 	_, err = blobURL.Upload(ctx,
 		pipeline.NewRequestBodyProgress(requestBody, func(bytesTransferred int64) {
-			fmt.Printf("Wrote %d of %d bytes.", bytesTransferred, requestBody.Len())
+			fmt.Printf("Wrote %d of %d bytes.", bytesTransferred, requestBody.Size())
 		}),
 		azblob.BlobHTTPHeaders{
 			ContentType:        "text/html; charset=utf-8",


### PR DESCRIPTION
For small chunks copy/pasting this example will result in `Wrote x of 0 bytes.`

`Len()` returns the number of bytes of the unread portion of the string, `Size()` returns the length of the underlying string.