### PR TITLE
Tidy retry delay jitter calculations

### DIFF
--- a/azblob/zc_policy_retry.go
+++ b/azblob/zc_policy_retry.go
@@ -120,7 +120,8 @@ func (o RetryOptions) calcDelay(try int32) time.Duration { // try is >=1; never 
 	}
 
 	// Introduce some jitter:  [0.0, 1.0) / 2 = [0.0, 0.5) + 0.8 = [0.8, 1.3)
-	delay = time.Duration(delay.Seconds() * (rand.Float64()/2 + 0.8) * float64(time.Second)) // NOTE: We want math/rand; not crypto/rand
+	// For casts and rounding - be careful, as per https://github.com/golang/go/issues/20757
+	delay = time.Duration(float32(delay) * (rand.Float32()/2 + 0.8)) // NOTE: We want math/rand; not crypto/rand
 	if delay > o.MaxRetryDelay {
 		delay = o.MaxRetryDelay
 	}
@@ -157,7 +158,8 @@ func NewRetryPolicyFactory(o RetryOptions) pipeline.Factory {
 					logf("Primary try=%d, Delay=%v\n", primaryTry, delay)
 					time.Sleep(delay) // The 1st try returns 0 delay
 				} else {
-					delay := time.Second * time.Duration(rand.Float32()/2+0.8)
+					// For casts and rounding - be careful, as per https://github.com/golang/go/issues/20757
+					delay := time.Duration(float32(time.Second) * (rand.Float32()/2 + 0.8))
 					logf("Secondary try=%d, Delay=%v\n", try-primaryTry, delay)
 					time.Sleep(delay) // Delay with some jitter before trying secondary
 				}


### PR DESCRIPTION
Jitter calc for trying secondary was wrong.  For primary it was correct, so just tidied the formula up for consistency.