### PR TITLE
SAS Snapshot support added

### DIFF
--- a/azblob/sas_service.go
+++ b/azblob/sas_service.go
@@ -32,26 +32,6 @@ type BlobSASSignatureValues struct {
 func (v BlobSASSignatureValues) NewSASQueryParameters(sharedKeyCredential *SharedKeyCredential) (SASQueryParameters, error) {
 	resource := "c"
 	if v.SnapshotTime.IsZero() {
-		if v.BlobName == "" {
-			// Make sure the permission characters are in the correct order
-			perms := &ContainerSASPermissions{}
-			if err := perms.Parse(v.Permissions); err != nil {
-				return SASQueryParameters{}, err
-			}
-			v.Permissions = perms.String()
-		} else {
-			resource = "b"
-			// Make sure the permission characters are in the correct order
-			perms := &BlobSASPermissions{}
-			if err := perms.Parse(v.Permissions); err != nil {
-				return SASQueryParameters{}, err
-			}
-			v.Permissions = perms.String()
-		}
-		if v.Version == "" {
-			v.Version = SASVersion
-		}
-	} else {
 		resource = "bs"
 
 		perms := &ContainerSASPermissions{}
@@ -62,6 +42,24 @@ func (v BlobSASSignatureValues) NewSASQueryParameters(sharedKeyCredential *Share
 		if v.Version == "" {
 			v.Version = SASVersion
 		}
+	} else if v.BlobName == "" {
+		// Make sure the permission characters are in the correct order
+		perms := &ContainerSASPermissions{}
+		if err := perms.Parse(v.Permissions); err != nil {
+			return SASQueryParameters{}, err
+		}
+		v.Permissions = perms.String()
+	} else {
+		resource = "b"
+		// Make sure the permission characters are in the correct order
+		perms := &BlobSASPermissions{}
+		if err := perms.Parse(v.Permissions); err != nil {
+			return SASQueryParameters{}, err
+		}
+		v.Permissions = perms.String()
+	}
+	if v.Version == "" {
+		v.Version = SASVersion
 	}
 	startTime, expiryTime, snapshotTime := FormatTimesForSASSigning(v.StartTime, v.ExpiryTime, v.SnapshotTime)
 

--- a/azblob/zc_sas_query_params.go
+++ b/azblob/zc_sas_query_params.go
@@ -22,7 +22,7 @@ const (
 
 // FormatTimesForSASSigning converts a time.Time to a snapshotTimeFormat string suitable for a
 // SASField's StartTime or ExpiryTime fields. Returns "" if value.IsZero().
-func FormatTimesForSASSigning(startTime, expiryTime time.Time) (string, string) {
+func FormatTimesForSASSigning(startTime, expiryTime, snapshotTime time.Time) (string, string, string) {
 	ss := ""
 	if !startTime.IsZero() {
 		ss = startTime.Format(SASTimeFormat) // "yyyy-MM-ddTHH:mm:ssZ"
@@ -31,7 +31,11 @@ func FormatTimesForSASSigning(startTime, expiryTime time.Time) (string, string) 
 	if !expiryTime.IsZero() {
 		se = expiryTime.Format(SASTimeFormat) // "yyyy-MM-ddTHH:mm:ssZ"
 	}
-	return ss, se
+	sh := ""
+	if !expiryTime.IsZero() {
+		sh = expiryTime.Format(SASTimeFormat)
+	}
+	return ss, se, sh
 }
 
 // SASTimeFormat represents the format of a SAS start or expiry time. Use it when formatting/parsing a time.Time.


### PR DESCRIPTION
This commit adds support for the creation of SAS Snapshot tokens.

I'm unsure about the change of the core file `zc_sas_query_params.go`, as if this is acceptable, it may have to be migrated to other Go azure storage SDKs. However, I also felt it was "dirty" to just use two of the `FormatTimesForSASSigning` function in order to achieve this.