### PR TITLE
add more error checking to downloadBlobToBuffer

### DIFF
--- a/azblob/highlevel.go
+++ b/azblob/highlevel.go
@@ -205,6 +205,9 @@ func downloadBlobToBuffer(ctx context.Context, blobURL BlobURL, offset int64, co
 		parallelism:   o.Parallelism,
 		operation: func(chunkStart int64, count int64) error {
 			dr, err := blobURL.Download(ctx, chunkStart+offset, count, o.AccessConditions, false)
+			if err != nil {
+				return err
+			}
 			body := dr.Body(o.RetryReaderOptionsPerBlock)
 			if o.Progress != nil {
 				rangeProgress := int64(0)


### PR DESCRIPTION
Closes #134 

This should help prevent nil pointer panics.