### PR TITLE
Expose GetAccountInfo to the user

### DIFF
--- a/azblob/url_append_blob.go
+++ b/azblob/url_append_blob.go
@@ -42,6 +42,10 @@ func (ab AppendBlobURL) WithSnapshot(snapshot string) AppendBlobURL {
 	return NewAppendBlobURL(p.URL(), ab.blobClient.Pipeline())
 }
 
+func (ab AppendBlobURL) GetAccountInfo(ctx context.Context) (*BlobGetAccountInfoResponse, error) {
+	return ab.blobClient.GetAccountInfo(ctx)
+}
+
 // Create creates a 0-length append blob. Call AppendBlock to append data to an append blob.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/put-blob.
 func (ab AppendBlobURL) Create(ctx context.Context, h BlobHTTPHeaders, metadata Metadata, ac BlobAccessConditions) (*AppendBlobCreateResponse, error) {

--- a/azblob/url_blob.go
+++ b/azblob/url_blob.go
@@ -29,6 +29,10 @@ func (b BlobURL) String() string {
 	return u.String()
 }
 
+func (b BlobURL) GetAccountInfo(ctx context.Context) (*BlobGetAccountInfoResponse, error) {
+	return b.blobClient.GetAccountInfo(ctx)
+}
+
 // WithPipeline creates a new BlobURL object identical to the source but with the specified request policy pipeline.
 func (b BlobURL) WithPipeline(p pipeline.Pipeline) BlobURL {
 	return NewBlobURL(b.blobClient.URL(), p)

--- a/azblob/url_block_blob.go
+++ b/azblob/url_block_blob.go
@@ -48,6 +48,10 @@ func (bb BlockBlobURL) WithSnapshot(snapshot string) BlockBlobURL {
 	return NewBlockBlobURL(p.URL(), bb.blobClient.Pipeline())
 }
 
+func (bb BlockBlobURL) GetAccountInfo(ctx context.Context) (*BlobGetAccountInfoResponse, error) {
+	return bb.blobClient.GetAccountInfo(ctx)
+}
+
 // Upload creates a new block blob or overwrites an existing block blob.
 // Updating an existing block blob overwrites any existing metadata on the blob. Partial updates are not
 // supported with Upload; the content of the existing blob is overwritten with the new content. To

--- a/azblob/url_container.go
+++ b/azblob/url_container.go
@@ -32,6 +32,10 @@ func (c ContainerURL) String() string {
 	return u.String()
 }
 
+func (c ContainerURL) GetAccountInfo(ctx context.Context) (*ContainerGetAccountInfoResponse, error) {
+	return c.client.GetAccountInfo(ctx)
+}
+
 // WithPipeline creates a new ContainerURL object identical to the source but with the specified request policy pipeline.
 func (c ContainerURL) WithPipeline(p pipeline.Pipeline) ContainerURL {
 	return NewContainerURL(c.URL(), p)

--- a/azblob/url_page_blob.go
+++ b/azblob/url_page_blob.go
@@ -44,6 +44,10 @@ func (pb PageBlobURL) WithSnapshot(snapshot string) PageBlobURL {
 	return NewPageBlobURL(p.URL(), pb.blobClient.Pipeline())
 }
 
+func (pb PageBlobURL) GetAccountInfo(ctx context.Context) (*BlobGetAccountInfoResponse, error) {
+	return pb.blobClient.GetAccountInfo(ctx)
+}
+
 // Create creates a page blob of the specified length. Call PutPage to upload data data to a page blob.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/put-blob.
 func (pb PageBlobURL) Create(ctx context.Context, size int64, sequenceNumber int64, h BlobHTTPHeaders, metadata Metadata, ac BlobAccessConditions) (*PageBlobCreateResponse, error) {

--- a/azblob/url_service.go
+++ b/azblob/url_service.go
@@ -38,6 +38,11 @@ func (s ServiceURL) GetUserDelegationCredential(ctx context.Context, info KeyInf
 	return NewUserDelegationCredential(strings.Split(s.client.url.Host, ".")[0], *udk), nil
 }
 
+func (s ServiceURL) GetAccountInfo(ctx context.Context) (*ServiceGetAccountInfoResponse, error) {
+	accountInfo, err := s.client.GetAccountInfo(ctx)
+	return accountInfo, err
+}
+
 // URL returns the URL endpoint used by the ServiceURL object.
 func (s ServiceURL) URL() url.URL {
 	return s.client.URL()

--- a/azblob/url_service.go
+++ b/azblob/url_service.go
@@ -39,8 +39,7 @@ func (s ServiceURL) GetUserDelegationCredential(ctx context.Context, info KeyInf
 }
 
 func (s ServiceURL) GetAccountInfo(ctx context.Context) (*ServiceGetAccountInfoResponse, error) {
-	accountInfo, err := s.client.GetAccountInfo(ctx)
-	return accountInfo, err
+	return s.client.GetAccountInfo(ctx)
 }
 
 // URL returns the URL endpoint used by the ServiceURL object.

--- a/azblob/zt_url_service_test.go
+++ b/azblob/zt_url_service_test.go
@@ -9,6 +9,14 @@ import (
 	chk "gopkg.in/check.v1" // go get gopkg.in/check.v1
 )
 
+func (s *aztestsSuite) TestGetAccountInfo(c *chk.C) {
+	sa := getBSU()
+
+	// Ensure the call succeeded. Don't test for specific account properties because we can't/don't want to set account properties.
+	_, err := sa.GetAccountInfo(context.Background())
+	c.Assert(err, chk.IsNil)
+}
+
 func (s *aztestsSuite) TestListContainers(c *chk.C) {
 	sa := getBSU()
 	resp, err := sa.ListContainersSegment(context.Background(), azblob.Marker{}, azblob.ListContainersSegmentOptions{Prefix: containerPrefix})

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,3 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 )
+
+go 1.13


### PR DESCRIPTION
This is required for azcopy to handle SetTier errors more gracefully.