### PR TITLE
Fix Go SDK handling of SAS timestamps

### DIFF
--- a/azblob/zc_sas_query_params.go
+++ b/azblob/zc_sas_query_params.go
@@ -41,7 +41,7 @@ func FormatTimesForSASSigning(startTime, expiryTime, snapshotTime time.Time) (st
 
 // SASTimeFormat represents the format of a SAS start or expiry time. Use it when formatting/parsing a time.Time.
 const SASTimeFormat = "2006-01-02T15:04:05Z" //"2017-07-27T00:00:00Z" // ISO 8601
-var SASTimeFormats = []string{SASTimeFormat, "2006-01-02T15:04Z", "2006-01-02"} // ISO 8601 formats, please refer to https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas for more details.
+var SASTimeFormats = []string{"2006-01-02T15:04:05.0000000Z", SASTimeFormat, "2006-01-02T15:04Z", "2006-01-02"} // ISO 8601 formats, please refer to https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas for more details.
 
 // formatSASTimeWithDefaultFormat format time with ISO 8601 in "yyyy-MM-ddTHH:mm:ssZ".
 func formatSASTimeWithDefaultFormat(t *time.Time) string {

--- a/azblob/zc_sas_query_params.go
+++ b/azblob/zc_sas_query_params.go
@@ -1,6 +1,7 @@
 package azblob
 
 import (
+	"errors"
 	"net"
 	"net/url"
 	"strings"
@@ -25,11 +26,11 @@ const (
 func FormatTimesForSASSigning(startTime, expiryTime, snapshotTime time.Time) (string, string, string) {
 	ss := ""
 	if !startTime.IsZero() {
-		ss = startTime.Format(SASTimeFormat) // "yyyy-MM-ddTHH:mm:ssZ"
+		ss = formatSASTimeWithDefaultFormat(&startTime)
 	}
 	se := ""
 	if !expiryTime.IsZero() {
-		se = expiryTime.Format(SASTimeFormat) // "yyyy-MM-ddTHH:mm:ssZ"
+		se = formatSASTimeWithDefaultFormat(&expiryTime)
 	}
 	sh := ""
 	if !snapshotTime.IsZero() {
@@ -40,6 +41,37 @@ func FormatTimesForSASSigning(startTime, expiryTime, snapshotTime time.Time) (st
 
 // SASTimeFormat represents the format of a SAS start or expiry time. Use it when formatting/parsing a time.Time.
 const SASTimeFormat = "2006-01-02T15:04:05Z" //"2017-07-27T00:00:00Z" // ISO 8601
+var SASTimeFormats = []string{SASTimeFormat, "2006-01-02T15:04Z", "2006-01-02"} // ISO 8601 formats, please refer to https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas for more details.
+
+// formatSASTimeWithDefaultFormat format time with ISO 8601 in "yyyy-MM-ddTHH:mm:ssZ".
+func formatSASTimeWithDefaultFormat(t *time.Time) string {
+	return formatSASTime(t, SASTimeFormat) // By default, "yyyy-MM-ddTHH:mm:ssZ" is used
+}
+
+// formatSASTime format time with given format, use ISO 8601 in "yyyy-MM-ddTHH:mm:ssZ" by default.
+func formatSASTime(t *time.Time, format string) string {
+	if format != "" {
+		return t.Format(format)
+	}
+	return t.Format(SASTimeFormat) // By default, "yyyy-MM-ddTHH:mm:ssZ" is used
+}
+
+// parseSASTimeString try to parse sas time string.
+func parseSASTimeString(val string) (t time.Time, timeFormat string, err error) {
+	for _, sasTimeFormat := range SASTimeFormats {
+		t, err = time.Parse(sasTimeFormat, val)
+		if err == nil {
+			timeFormat = sasTimeFormat
+			break
+		}
+	}
+
+	if err != nil {
+		err = errors.New("fail to parse time with IOS 8601 formats, please refer to https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas for more details")
+	}
+
+	return
+}
 
 // https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas
 
@@ -74,6 +106,10 @@ type SASQueryParameters struct {
 	signedExpiry       time.Time   `param:"ske"`
 	signedService      string      `param:"sks"`
 	signedVersion      string      `param:"skv"`
+
+	// private member used for startTime and expiryTime formatting.
+	stTimeFormat       string
+	seTimeFormat       string
 }
 
 func (p *SASQueryParameters) SignedOid() string {
@@ -202,9 +238,9 @@ func newSASQueryParameters(values url.Values, deleteSASParametersFromValues bool
 		case "snapshot":
 			p.snapshotTime, _ = time.Parse(SnapshotTimeFormat, val)
 		case "st":
-			p.startTime, _ = time.Parse(SASTimeFormat, val)
+			p.startTime, p.stTimeFormat, _ = parseSASTimeString(val)
 		case "se":
-			p.expiryTime, _ = time.Parse(SASTimeFormat, val)
+			p.expiryTime, p.seTimeFormat, _ = parseSASTimeString(val)
 		case "sip":
 			dashIndex := strings.Index(val, "-")
 			if dashIndex == -1 {
@@ -268,10 +304,10 @@ func (p *SASQueryParameters) addToValues(v url.Values) url.Values {
 		v.Add("spr", string(p.protocol))
 	}
 	if !p.startTime.IsZero() {
-		v.Add("st", p.startTime.Format(SASTimeFormat))
+		v.Add("st", formatSASTime(&(p.startTime), p.stTimeFormat))
 	}
 	if !p.expiryTime.IsZero() {
-		v.Add("se", p.expiryTime.Format(SASTimeFormat))
+		v.Add("se", formatSASTime(&(p.expiryTime), p.seTimeFormat))
 	}
 	if len(p.ipRange.Start) > 0 {
 		v.Add("sip", p.ipRange.String())

--- a/azblob/zt_url_blob_test.go
+++ b/azblob/zt_url_blob_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -1890,4 +1891,53 @@ func (s *aztestsSuite) TestBlobTierInvalidValue(c *chk.C) {
 
 	_, err = blobURL.SetTier(ctx, AccessTierType("garbage"), LeaseAccessConditions{})
 	validateStorageError(c, err, ServiceCodeInvalidHeaderValue)
+}
+
+func (s *aztestsSuite) TestBlobURLPartsSASQueryTimes(c *chk.C) {
+	StartTimesInputs := []string{
+		"2020-04-20",
+		"2020-04-20T07:00Z",
+		"2020-04-20T07:15:00Z",
+	}
+	StartTimesExpected := []time.Time{
+		time.Date(2020, time.April, 20, 0, 0, 0, 0, time.UTC),
+		time.Date(2020, time.April, 20, 7, 0, 0, 0, time.UTC),
+		time.Date(2020, time.April, 20, 7, 15, 0, 0, time.UTC),
+	}
+	ExpiryTimesInputs := []string{
+		"2020-04-21",
+		"2020-04-20T08:00Z",
+		"2020-04-20T08:15:00Z",
+	}
+	ExpiryTimesExpected := []time.Time{
+		time.Date(2020, time.April, 21, 0, 0, 0, 0, time.UTC),
+		time.Date(2020, time.April, 20, 8, 0, 0, 0, time.UTC),
+		time.Date(2020, time.April, 20, 8, 15, 0, 0, time.UTC),
+	}
+
+	for i := 0; i < len(StartTimesInputs); i++ {
+		urlString :=
+			"https://myaccount.blob.core.windows.net/mycontainer/mydirectory/myfile.txt?" +
+			"se=" + url.QueryEscape(ExpiryTimesInputs[i]) + "&" +
+			"sig=NotASignature&" +
+			"sp=r&" +
+			"spr=https&" +
+			"sr=b&" +
+			"st=" + url.QueryEscape(StartTimesInputs[i]) + "&" +
+			"sv=2019-10-10"
+		url, _ := url.Parse(urlString)
+
+		parts := NewBlobURLParts(*url)
+		c.Assert(parts.Scheme, chk.Equals, "https")
+		c.Assert(parts.Host, chk.Equals, "myaccount.blob.core.windows.net")
+		c.Assert(parts.ContainerName, chk.Equals, "mycontainer")
+		c.Assert(parts.BlobName, chk.Equals, "mydirectory/myfile.txt")
+
+		sas := parts.SAS
+		c.Assert(sas.StartTime(), chk.Equals, StartTimesExpected[i])
+		c.Assert(sas.ExpiryTime(), chk.Equals, ExpiryTimesExpected[i])
+
+		uResult := parts.URL()
+		c.Assert(uResult.String(), chk.Equals, urlString)
+	}
 }

--- a/azblob/zt_url_blob_test.go
+++ b/azblob/zt_url_blob_test.go
@@ -1898,21 +1898,25 @@ func (s *aztestsSuite) TestBlobURLPartsSASQueryTimes(c *chk.C) {
 		"2020-04-20",
 		"2020-04-20T07:00Z",
 		"2020-04-20T07:15:00Z",
+		"2020-04-20T07:30:00.1234567Z",
 	}
 	StartTimesExpected := []time.Time{
 		time.Date(2020, time.April, 20, 0, 0, 0, 0, time.UTC),
 		time.Date(2020, time.April, 20, 7, 0, 0, 0, time.UTC),
 		time.Date(2020, time.April, 20, 7, 15, 0, 0, time.UTC),
+		time.Date(2020, time.April, 20, 7, 30, 0, 123456700, time.UTC),
 	}
 	ExpiryTimesInputs := []string{
 		"2020-04-21",
 		"2020-04-20T08:00Z",
 		"2020-04-20T08:15:00Z",
+		"2020-04-20T08:30:00.2345678Z",
 	}
 	ExpiryTimesExpected := []time.Time{
 		time.Date(2020, time.April, 21, 0, 0, 0, 0, time.UTC),
 		time.Date(2020, time.April, 20, 8, 0, 0, 0, time.UTC),
 		time.Date(2020, time.April, 20, 8, 15, 0, 0, time.UTC),
+		time.Date(2020, time.April, 20, 8, 30, 0, 234567800, time.UTC),
 	}
 
 	for i := 0; i < len(StartTimesInputs); i++ {


### PR DESCRIPTION
The Go SDK currently rewrites SAS timestamps to always match a specific format (`"2006-01-02T15:04:05Z"`).  This is a problem, because if the timestamp doesn't roundtrip cleanly (i.e. a timestamp not matching that exact pattern) will be unusable with the Go SDK, because the SAS will get rewritten without regenerating the signature.

This change updates `SASQueryParameters` and friends to retain timestamps as their original string values, instead of as a `Time`.  This should eliminate roundtripping issues, since the timestamps will no longer be rewritten.

I will note that given my API surface changes, this is a breaking change.  I'm not sure how the Go SDK wants to handle breaking changes; it's still in preview so maybe you're not worried about them! 
 I think it's a breaking change worth taking too, but in case you disagree I'm happy to try to rewrite it to be a little more defensive on the API surface changes, I just didn't want to start there.

Separately, this is my first real change written in Go.  Please do not hesitate to call out any Go-isms and whatnot that I may have missed. :smile:

Resolves #168