### PR TITLE
[Go][Blob][2019-02-02] Set tier support on copy/put blob API

### DIFF
--- a/azblob/chunkwriting.go
+++ b/azblob/chunkwriting.go
@@ -17,7 +17,7 @@ import (
 // This allows us to provide a local implementation that fakes the server for hermetic testing.
 type blockWriter interface {
 	StageBlock(context.Context, string, io.ReadSeeker, LeaseAccessConditions, []byte) (*BlockBlobStageBlockResponse, error)
-	CommitBlockList(context.Context, []string, BlobHTTPHeaders, Metadata, BlobAccessConditions) (*BlockBlobCommitBlockListResponse, error)
+	CommitBlockList(context.Context, []string, BlobHTTPHeaders, Metadata, BlobAccessConditions, AccessTierType) (*BlockBlobCommitBlockListResponse, error)
 }
 
 // copyFromReader copies a source io.Reader to blob storage using concurrent uploads.
@@ -201,7 +201,7 @@ func (c *copier) close() error {
 	}
 
 	var err error
-	c.result, err = c.to.CommitBlockList(c.ctx, c.id.issued(), c.o.BlobHTTPHeaders, c.o.Metadata, c.o.AccessConditions)
+	c.result, err = c.to.CommitBlockList(c.ctx, c.id.issued(), c.o.BlobHTTPHeaders, c.o.Metadata, c.o.AccessConditions, c.o.BlobAccessTier)
 	return err
 }
 

--- a/azblob/chunkwriting_test.go
+++ b/azblob/chunkwriting_test.go
@@ -58,7 +58,7 @@ func (f *fakeBlockWriter) StageBlock(ctx context.Context, blockID string, r io.R
 	return &BlockBlobStageBlockResponse{}, nil
 }
 
-func (f *fakeBlockWriter) CommitBlockList(ctx context.Context, blockIDs []string, headers BlobHTTPHeaders, meta Metadata, access BlobAccessConditions) (*BlockBlobCommitBlockListResponse, error) {
+func (f *fakeBlockWriter) CommitBlockList(ctx context.Context, blockIDs []string, headers BlobHTTPHeaders, meta Metadata, access BlobAccessConditions, tier AccessTierType) (*BlockBlobCommitBlockListResponse, error) {
 	dst, err := os.OpenFile(filepath.Join(f.path, finalFileName), os.O_CREATE+os.O_WRONLY, 0600)
 	if err != nil {
 		return nil, err

--- a/azblob/highlevel.go
+++ b/azblob/highlevel.go
@@ -130,7 +130,7 @@ func UploadBufferToBlockBlob(ctx context.Context, b []byte,
 		return nil, err
 	}
 	// All put blocks were successful, call Put Block List to finalize the blob
-	return blockBlobURL.CommitBlockList(ctx, blockIDList, o.BlobHTTPHeaders, o.Metadata, o.AccessConditions)
+	return blockBlobURL.CommitBlockList(ctx, blockIDList, o.BlobHTTPHeaders, o.Metadata, o.AccessConditions, DefaultAccessTier)
 }
 
 // UploadFileToBlockBlob uploads a file in blocks to a block blob.
@@ -363,6 +363,7 @@ type UploadStreamToBlockBlobOptions struct {
 	BlobHTTPHeaders  BlobHTTPHeaders
 	Metadata         Metadata
 	AccessConditions BlobAccessConditions
+	BlobAccessTier   AccessTierType
 }
 
 func (u *UploadStreamToBlockBlobOptions) defaults() {

--- a/azblob/highlevel.go
+++ b/azblob/highlevel.go
@@ -86,7 +86,7 @@ func UploadBufferToBlockBlob(ctx context.Context, b []byte,
 		if o.Progress != nil {
 			body = pipeline.NewRequestBodyProgress(body, o.Progress)
 		}
-		return blockBlobURL.Upload(ctx, body, o.BlobHTTPHeaders, o.Metadata, o.AccessConditions)
+		return blockBlobURL.Upload(ctx, body, o.BlobHTTPHeaders, o.Metadata, o.AccessConditions, DefaultAccessTier)
 	}
 
 	var numBlocks = uint16(((bufferSize - 1) / o.BlockSize) + 1)

--- a/azblob/highlevel.go
+++ b/azblob/highlevel.go
@@ -55,6 +55,9 @@ type UploadToBlockBlobOptions struct {
 	// AccessConditions indicates the access conditions for the block blob.
 	AccessConditions BlobAccessConditions
 
+	// BlobAccessTier indicates the tier of blob
+	BlobAccessTier AccessTierType
+
 	// Parallelism indicates the maximum number of blocks to upload in parallel (0=default)
 	Parallelism uint16
 }
@@ -86,7 +89,7 @@ func UploadBufferToBlockBlob(ctx context.Context, b []byte,
 		if o.Progress != nil {
 			body = pipeline.NewRequestBodyProgress(body, o.Progress)
 		}
-		return blockBlobURL.Upload(ctx, body, o.BlobHTTPHeaders, o.Metadata, o.AccessConditions, DefaultAccessTier)
+		return blockBlobURL.Upload(ctx, body, o.BlobHTTPHeaders, o.Metadata, o.AccessConditions, o.BlobAccessTier)
 	}
 
 	var numBlocks = uint16(((bufferSize - 1) / o.BlockSize) + 1)
@@ -130,7 +133,7 @@ func UploadBufferToBlockBlob(ctx context.Context, b []byte,
 		return nil, err
 	}
 	// All put blocks were successful, call Put Block List to finalize the blob
-	return blockBlobURL.CommitBlockList(ctx, blockIDList, o.BlobHTTPHeaders, o.Metadata, o.AccessConditions, DefaultAccessTier)
+	return blockBlobURL.CommitBlockList(ctx, blockIDList, o.BlobHTTPHeaders, o.Metadata, o.AccessConditions, o.BlobAccessTier)
 }
 
 // UploadFileToBlockBlob uploads a file in blocks to a block blob.

--- a/azblob/url_blob.go
+++ b/azblob/url_blob.go
@@ -12,6 +12,8 @@ type BlobURL struct {
 	blobClient blobClient
 }
 
+var DefaultAccessTier AccessTierType = AccessTierHot
+
 // NewBlobURL creates a BlobURL object using the specified URL and request policy pipeline.
 func NewBlobURL(url url.URL, p pipeline.Pipeline) BlobURL {
 	blobClient := newBlobClient(url, p)

--- a/azblob/url_blob.go
+++ b/azblob/url_blob.go
@@ -12,7 +12,8 @@ type BlobURL struct {
 	blobClient blobClient
 }
 
-var DefaultAccessTier AccessTierType = AccessTierHot
+var DefaultAccessTier AccessTierType = AccessTierNone
+var DefaultPremiumBlobAccessTier PremiumPageBlobAccessTierType = PremiumPageBlobAccessTierNone
 
 // NewBlobURL creates a BlobURL object using the specified URL and request policy pipeline.
 func NewBlobURL(url url.URL, p pipeline.Pipeline) BlobURL {
@@ -252,13 +253,13 @@ func leasePeriodPointer(period int32) (p *int32) {
 
 // StartCopyFromURL copies the data at the source URL to a blob.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/copy-blob.
-func (b BlobURL) StartCopyFromURL(ctx context.Context, source url.URL, metadata Metadata, srcac ModifiedAccessConditions, dstac BlobAccessConditions) (*BlobStartCopyFromURLResponse, error) {
+func (b BlobURL) StartCopyFromURL(ctx context.Context, source url.URL, metadata Metadata, srcac ModifiedAccessConditions, dstac BlobAccessConditions, tier AccessTierType) (*BlobStartCopyFromURLResponse, error) {
 	srcIfModifiedSince, srcIfUnmodifiedSince, srcIfMatchETag, srcIfNoneMatchETag := srcac.pointers()
 	dstIfModifiedSince, dstIfUnmodifiedSince, dstIfMatchETag, dstIfNoneMatchETag := dstac.ModifiedAccessConditions.pointers()
 	dstLeaseID := dstac.LeaseAccessConditions.pointers()
 
 	return b.blobClient.StartCopyFromURL(ctx, source.String(), nil, metadata,
-		AccessTierNone, RehydratePriorityNone, srcIfModifiedSince, srcIfUnmodifiedSince,
+		tier, RehydratePriorityNone, srcIfModifiedSince, srcIfUnmodifiedSince,
 		srcIfMatchETag, srcIfNoneMatchETag,
 		nil, // Blob tags
 		dstIfModifiedSince, dstIfUnmodifiedSince,

--- a/azblob/url_block_blob.go
+++ b/azblob/url_block_blob.go
@@ -114,14 +114,14 @@ func (bb BlockBlobURL) StageBlockFromURL(ctx context.Context, base64BlockID stri
 // blocks together. Any blocks not specified in the block list and permanently deleted.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/put-block-list.
 func (bb BlockBlobURL) CommitBlockList(ctx context.Context, base64BlockIDs []string, h BlobHTTPHeaders,
-	metadata Metadata, ac BlobAccessConditions) (*BlockBlobCommitBlockListResponse, error) {
+	metadata Metadata, ac BlobAccessConditions, tier AccessTierType) (*BlockBlobCommitBlockListResponse, error) {
 	ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag := ac.ModifiedAccessConditions.pointers()
 	return bb.bbClient.CommitBlockList(ctx, BlockLookupList{Latest: base64BlockIDs}, nil,
 		&h.CacheControl, &h.ContentType, &h.ContentEncoding, &h.ContentLanguage, h.ContentMD5, nil, nil,
 		metadata, ac.LeaseAccessConditions.pointers(), &h.ContentDisposition,
 		nil, nil, EncryptionAlgorithmNone, // CPK
 		nil, // CPK-N
-		AccessTierNone,
+		tier,
 		ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag,
 		nil, // Blob tags
 		nil,
@@ -140,13 +140,13 @@ func (bb BlockBlobURL) GetBlockList(ctx context.Context, listType BlockListType,
 // CopyFromURL synchronously copies the data at the source URL to a block blob, with sizes up to 256 MB.
 // For more information, see https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url.
 func (bb BlockBlobURL) CopyFromURL(ctx context.Context, source url.URL, metadata Metadata,
-	srcac ModifiedAccessConditions, dstac BlobAccessConditions, srcContentMD5 []byte) (*BlobCopyFromURLResponse, error) {
+	srcac ModifiedAccessConditions, dstac BlobAccessConditions, srcContentMD5 []byte, tier AccessTierType) (*BlobCopyFromURLResponse, error) {
 
 	srcIfModifiedSince, srcIfUnmodifiedSince, srcIfMatchETag, srcIfNoneMatchETag := srcac.pointers()
 	dstIfModifiedSince, dstIfUnmodifiedSince, dstIfMatchETag, dstIfNoneMatchETag := dstac.ModifiedAccessConditions.pointers()
 	dstLeaseID := dstac.LeaseAccessConditions.pointers()
 
-	return bb.blobClient.CopyFromURL(ctx, source.String(), nil, metadata, AccessTierNone,
+	return bb.blobClient.CopyFromURL(ctx, source.String(), nil, metadata, tier,
 		srcIfModifiedSince, srcIfUnmodifiedSince,
 		srcIfMatchETag, srcIfNoneMatchETag,
 		dstIfModifiedSince, dstIfUnmodifiedSince,

--- a/azblob/url_block_blob.go
+++ b/azblob/url_block_blob.go
@@ -64,7 +64,7 @@ func (bb BlockBlobURL) GetAccountInfo(ctx context.Context) (*BlobGetAccountInfoR
 // This method panics if the stream is not at position 0.
 // Note that the http client closes the body stream after the request is sent to the service.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/put-blob.
-func (bb BlockBlobURL) Upload(ctx context.Context, body io.ReadSeeker, h BlobHTTPHeaders, metadata Metadata, ac BlobAccessConditions) (*BlockBlobUploadResponse, error) {
+func (bb BlockBlobURL) Upload(ctx context.Context, body io.ReadSeeker, h BlobHTTPHeaders, metadata Metadata, ac BlobAccessConditions, tier AccessTierType) (*BlockBlobUploadResponse, error) {
 	ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag := ac.ModifiedAccessConditions.pointers()
 	count, err := validateSeekableStreamAt0AndGetCount(body)
 	if err != nil {
@@ -75,7 +75,7 @@ func (bb BlockBlobURL) Upload(ctx context.Context, body io.ReadSeeker, h BlobHTT
 		&h.CacheControl, metadata, ac.LeaseAccessConditions.pointers(), &h.ContentDisposition,
 		nil, nil, EncryptionAlgorithmNone, // CPK-V
 		nil, // CPK-N
-		AccessTierNone, ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag,
+		tier, ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag,
 		nil, // Blob tags
 		nil,
 		nil, // Blob tags

--- a/azblob/url_page_blob.go
+++ b/azblob/url_page_blob.go
@@ -58,9 +58,9 @@ func (pb PageBlobURL) GetAccountInfo(ctx context.Context) (*BlobGetAccountInfoRe
 
 // Create creates a page blob of the specified length. Call PutPage to upload data data to a page blob.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/put-blob.
-func (pb PageBlobURL) Create(ctx context.Context, size int64, sequenceNumber int64, h BlobHTTPHeaders, metadata Metadata, ac BlobAccessConditions) (*PageBlobCreateResponse, error) {
+func (pb PageBlobURL) Create(ctx context.Context, size int64, sequenceNumber int64, h BlobHTTPHeaders, metadata Metadata, ac BlobAccessConditions, tier PremiumPageBlobAccessTierType) (*PageBlobCreateResponse, error) {
 	ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag := ac.ModifiedAccessConditions.pointers()
-	return pb.pbClient.Create(ctx, 0, size, nil, PremiumPageBlobAccessTierNone,
+	return pb.pbClient.Create(ctx, 0, size, nil, tier,
 		&h.ContentType, &h.ContentEncoding, &h.ContentLanguage, h.ContentMD5, &h.CacheControl,
 		metadata, ac.LeaseAccessConditions.pointers(), &h.ContentDisposition,
 		nil, nil, EncryptionAlgorithmNone, // CPK-V

--- a/azblob/zt_blob_versioning_test.go
+++ b/azblob/zt_blob_versioning_test.go
@@ -58,7 +58,7 @@ func (s *aztestsSuite) TestCreateAndDownloadBlobSpecialCharactersWithVID(c *chk.
 	for i := 0; i < len(data); i++ {
 		blobName := "abc" + string(data[i])
 		blobURL := containerURL.NewBlockBlobURL(blobName)
-		resp, err := blobURL.Upload(ctx, strings.NewReader(string(data[i])), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+		resp, err := blobURL.Upload(ctx, strings.NewReader(string(data[i])), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 		c.Assert(err, chk.IsNil)
 		c.Assert(resp.VersionID(), chk.NotNil)
 
@@ -80,13 +80,13 @@ func (s *aztestsSuite) TestDeleteSpecificBlobVersion(c *chk.C) {
 	blobURL, _ := getBlockBlobURL(c, containerURL)
 
 	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{},
-		basicMetadata, BlobAccessConditions{})
+		basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.VersionID(), chk.NotNil)
 	versionID1 := blockBlobUploadResp.VersionID()
 
 	blockBlobUploadResp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{},
-		basicMetadata, BlobAccessConditions{})
+		basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.VersionID(), chk.NotNil)
 
@@ -118,13 +118,13 @@ func (s *aztestsSuite) TestDeleteSpecificBlobVersionWithBlobSAS(c *chk.C) {
 	blobURL, blobName := getBlockBlobURL(c, containerURL)
 
 	resp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{},
-		basicMetadata, BlobAccessConditions{})
+		basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	versionId := resp.VersionID()
 	c.Assert(versionId, chk.NotNil)
 
 	resp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{},
-		basicMetadata, BlobAccessConditions{})
+		basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.VersionID(), chk.NotNil)
 
@@ -159,13 +159,13 @@ func (s *aztestsSuite) TestDownloadSpecificBlobVersion(c *chk.C) {
 	blobURL, _ := getBlockBlobURL(c, containerURL)
 
 	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{},
-		basicMetadata, BlobAccessConditions{})
+		basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp, chk.NotNil)
 	versionId1 := blockBlobUploadResp.VersionID()
 
 	blockBlobUploadResp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{},
-		basicMetadata, BlobAccessConditions{})
+		basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp, chk.NotNil)
 	versionId2 := blockBlobUploadResp.VersionID()
@@ -192,7 +192,7 @@ func (s *aztestsSuite) TestCreateBlobSnapshotReturnsVID(c *chk.C) {
 	defer delContainer(c, containerURL)
 	blobURL := containerURL.NewBlockBlobURL(generateBlobName())
 	uploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{},
-		basicMetadata, BlobAccessConditions{})
+		basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadResp.VersionID(), chk.NotNil)
 
@@ -236,7 +236,7 @@ func (s *aztestsSuite) TestCopyBlobFromURLWithSASReturnsVID(c *chk.C) {
 	srcBlob := container.NewBlockBlobURL(generateBlobName())
 	destBlob := container.NewBlockBlobURL(generateBlobName())
 
-	uploadSrcResp, err := srcBlob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	uploadSrcResp, err := srcBlob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadSrcResp.Response().StatusCode, chk.Equals, 201)
 	c.Assert(uploadSrcResp.Response().Header.Get("x-ms-version-id"), chk.NotNil)
@@ -294,7 +294,7 @@ func (s *aztestsSuite) TestCreateBlockBlobReturnsVID(c *chk.C) {
 	blobURL := containerURL.NewBlockBlobURL(generateBlobName())
 
 	// Prepare source blob for copy.
-	uploadResp, err := blobURL.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	uploadResp, err := blobURL.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadResp.Response().StatusCode, chk.Equals, 201)
 	c.Assert(uploadResp.rawResponse.Header.Get("x-ms-version"), chk.Equals, ServiceVersion)

--- a/azblob/zt_blob_versioning_test.go
+++ b/azblob/zt_blob_versioning_test.go
@@ -256,7 +256,7 @@ func (s *aztestsSuite) TestCopyBlobFromURLWithSASReturnsVID(c *chk.C) {
 
 	srcBlobURLWithSAS := srcBlobParts.URL()
 
-	resp, err := destBlob.CopyFromURL(ctx, srcBlobURLWithSAS, Metadata{"foo": "bar"}, ModifiedAccessConditions{}, BlobAccessConditions{}, sourceDataMD5Value[:])
+	resp, err := destBlob.CopyFromURL(ctx, srcBlobURLWithSAS, Metadata{"foo": "bar"}, ModifiedAccessConditions{}, BlobAccessConditions{}, sourceDataMD5Value[:], DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.Response().StatusCode, chk.Equals, 202)
 	c.Assert(resp.Version(), chk.Not(chk.Equals), "")
@@ -272,10 +272,10 @@ func (s *aztestsSuite) TestCopyBlobFromURLWithSASReturnsVID(c *chk.C) {
 	c.Assert(downloadResp.Response().Header.Get("x-ms-version-id"), chk.NotNil)
 	c.Assert(len(downloadResp.NewMetadata()), chk.Equals, 1)
 	_, badMD5 := getRandomDataAndReader(16)
-	_, err = destBlob.CopyFromURL(ctx, srcBlobURLWithSAS, Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{}, badMD5)
+	_, err = destBlob.CopyFromURL(ctx, srcBlobURLWithSAS, Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{}, badMD5, DefaultAccessTier)
 	c.Assert(err, chk.NotNil)
 
-	resp, err = destBlob.CopyFromURL(ctx, srcBlobURLWithSAS, Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{}, nil)
+	resp, err = destBlob.CopyFromURL(ctx, srcBlobURLWithSAS, Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{}, nil, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.Response().StatusCode, chk.Equals, 202)
 	c.Assert(resp.XMsContentCrc64(), chk.Not(chk.Equals), "")
@@ -352,7 +352,7 @@ func (s *aztestsSuite) TestPutBlockListReturnsVID(c *chk.C) {
 		c.Assert(resp.Version(), chk.Not(chk.Equals), "")
 	}
 
-	commitResp, err := blobURL.CommitBlockList(ctx, base64BlockIDs, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	commitResp, err := blobURL.CommitBlockList(ctx, base64BlockIDs, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(commitResp.VersionID(), chk.NotNil)
 

--- a/azblob/zt_examples_test.go
+++ b/azblob/zt_examples_test.go
@@ -716,7 +716,7 @@ func ExampleBlockBlobURL() {
 	}
 
 	// After all the blocks are uploaded, atomically commit them to the blob.
-	_, err = blobURL.CommitBlockList(ctx, base64BlockIDs, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	_, err = blobURL.CommitBlockList(ctx, base64BlockIDs, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -800,7 +800,7 @@ func ExamplePageBlobURL() {
 
 	ctx := context.Background() // This example uses a never-expiring context
 	_, err = blobURL.Create(ctx, PageBlobPageBytes*4, 0, BlobHTTPHeaders{},
-		Metadata{}, BlobAccessConditions{})
+		Metadata{}, BlobAccessConditions{}, DefaultPremiumBlobAccessTier)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -928,7 +928,7 @@ func Example_blobSnapshots() {
 	}
 
 	// Promote read-only snapshot to writable base blob:
-	_, err = baseBlobURL.StartCopyFromURL(ctx, snapshotBlobURL.URL(), Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{})
+	_, err = baseBlobURL.StartCopyFromURL(ctx, snapshotBlobURL.URL(), Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1013,7 +1013,7 @@ func ExampleBlobURL_startCopy() {
 	ctx := context.Background() // This example uses a never-expiring context
 
 	src, _ := url.Parse("https://cdn2.auth0.com/docs/media/addons/azure_blob.svg")
-	startCopy, err := blobURL.StartCopyFromURL(ctx, *src, nil, ModifiedAccessConditions{}, BlobAccessConditions{})
+	startCopy, err := blobURL.StartCopyFromURL(ctx, *src, nil, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/azblob/zt_examples_test.go
+++ b/azblob/zt_examples_test.go
@@ -72,7 +72,7 @@ func Example() {
 
 	// Create the blob with string (plain text) content.
 	data := "Hello World!"
-	_, err = blobURL.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{})
+	_, err = blobURL.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -430,7 +430,7 @@ func ExampleContainerURL_SetContainerAccessPolicy() {
 
 	// Create the blob and put some text in it
 	_, err = blobURL.Upload(ctx, strings.NewReader("Hello World!"), BlobHTTPHeaders{ContentType: "text/plain"},
-		Metadata{}, BlobAccessConditions{})
+		Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -494,7 +494,7 @@ func ExampleBlobAccessConditions() {
 	}
 
 	// Create the blob (unconditionally; succeeds)
-	upload, err := blobURL.Upload(ctx, strings.NewReader("Text-1"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	upload, err := blobURL.Upload(ctx, strings.NewReader("Text-1"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	showResult(upload, err)
 
 	// Download blob content if the blob has been modified since we uploaded it (fails):
@@ -507,7 +507,7 @@ func ExampleBlobAccessConditions() {
 
 	// Upload new content if the blob hasn't changed since the version identified by ETag (succeeds):
 	upload, err = blobURL.Upload(ctx, strings.NewReader("Text-2"), BlobHTTPHeaders{}, Metadata{},
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: upload.ETag()}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: upload.ETag()}}, DefaultAccessTier)
 	showResult(upload, err)
 
 	// Download content if it has changed since the version identified by ETag (fails):
@@ -516,7 +516,7 @@ func ExampleBlobAccessConditions() {
 
 	// Upload content if the blob doesn't already exist (fails):
 	showResult(blobURL.Upload(ctx, strings.NewReader("Text-3"), BlobHTTPHeaders{}, Metadata{},
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETagAny}}))
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETagAny}}, DefaultAccessTier))
 }
 
 // This examples shows how to create a container with metadata and then how to read & update the metadata.
@@ -586,7 +586,7 @@ func ExampleMetadata_blobs() {
 	// Therefore, you should always use lowercase letters; especially when querying a map for a metadata key.
 	creatingApp, _ := os.Executable()
 	_, err = blobURL.Upload(ctx, strings.NewReader("Some text"), BlobHTTPHeaders{},
-		Metadata{"author": "Jeffrey", "app": creatingApp}, BlobAccessConditions{})
+		Metadata{"author": "Jeffrey", "app": creatingApp}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -637,7 +637,7 @@ func ExampleBlobHTTPHeaders() {
 		BlobHTTPHeaders{
 			ContentType:        "text/html; charset=utf-8",
 			ContentDisposition: "attachment",
-		}, Metadata{}, BlobAccessConditions{})
+		}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -870,7 +870,7 @@ func Example_blobSnapshots() {
 	ctx := context.Background() // This example uses a never-expiring context
 
 	// Create the original blob:
-	_, err = baseBlobURL.Upload(ctx, strings.NewReader("Some text"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	_, err = baseBlobURL.Upload(ctx, strings.NewReader("Some text"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -880,7 +880,7 @@ func Example_blobSnapshots() {
 	snapshot := createSnapshot.Snapshot()
 
 	// Modify the original blob & show it:
-	_, err = baseBlobURL.Upload(ctx, strings.NewReader("New text"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	_, err = baseBlobURL.Upload(ctx, strings.NewReader("New text"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -973,7 +973,7 @@ func Example_progressUploadDownload() {
 		BlobHTTPHeaders{
 			ContentType:        "text/html; charset=utf-8",
 			ContentDisposition: "attachment",
-		}, Metadata{}, BlobAccessConditions{})
+		}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1259,7 +1259,7 @@ func ExampleListBlobsHierarchy() {
 	blobNames := []string{"a/1", "a/2", "b/1", "boaty_mcboatface"}
 	for _, blobName := range blobNames {
 		blobURL := containerURL.NewBlockBlobURL(blobName)
-		_, err := blobURL.Upload(ctx, strings.NewReader("test"), BlobHTTPHeaders{}, nil, BlobAccessConditions{})
+		_, err := blobURL.Upload(ctx, strings.NewReader("test"), BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultAccessTier)
 
 		if err != nil {
 			log.Fatal("an error occurred while creating blobs for the example setup")

--- a/azblob/zt_sas_blob_snapshot_test.go
+++ b/azblob/zt_sas_blob_snapshot_test.go
@@ -24,7 +24,7 @@ func (s *aztestsSuite) TestSnapshotSAS(c *chk.C) {
 	burl := containerURL.NewBlockBlobURL(blobName)
 	data := "Hello world!"
 
-	_, err = burl.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{})
+	_, err = burl.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func (s *aztestsSuite) TestSnapshotSAS(c *chk.C) {
 	//If this succeeds, it means a normal SAS token was created.
 
 	fsburl := containerURL.NewBlockBlobURL("failsnap")
-	_, err = fsburl.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{})
+	_, err = fsburl.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		c.Fatal(err) //should succeed to create the blob via normal auth means
 	}

--- a/azblob/zt_test.go
+++ b/azblob/zt_test.go
@@ -167,7 +167,7 @@ func createNewBlockBlob(c *chk.C, container ContainerURL) (blob BlockBlobURL, na
 	blob, name = getBlockBlobURL(c, container)
 
 	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), BlobHTTPHeaders{},
-		nil, BlobAccessConditions{})
+		nil, BlobAccessConditions{}, DefaultAccessTier)
 
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.StatusCode(), chk.Equals, 201)
@@ -209,7 +209,7 @@ func createBlockBlobWithPrefix(c *chk.C, container ContainerURL, prefix string) 
 	blob = container.NewBlockBlobURL(name)
 
 	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), BlobHTTPHeaders{},
-		nil, BlobAccessConditions{})
+		nil, BlobAccessConditions{}, DefaultAccessTier)
 
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.StatusCode(), chk.Equals, 201)

--- a/azblob/zt_test.go
+++ b/azblob/zt_test.go
@@ -188,7 +188,7 @@ func createNewAppendBlob(c *chk.C, container ContainerURL) (blob AppendBlobURL, 
 func createNewPageBlob(c *chk.C, container ContainerURL) (blob PageBlobURL, name string) {
 	blob, name = getPageBlobURL(c, container)
 
-	resp, err := blob.Create(ctx, PageBlobPageBytes*10, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{})
+	resp, err := blob.Create(ctx, PageBlobPageBytes*10, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.StatusCode(), chk.Equals, 201)
 	return
@@ -197,7 +197,7 @@ func createNewPageBlob(c *chk.C, container ContainerURL) (blob PageBlobURL, name
 func createNewPageBlobWithSize(c *chk.C, container ContainerURL, sizeInBytes int64) (blob PageBlobURL, name string) {
 	blob, name = getPageBlobURL(c, container)
 
-	resp, err := blob.Create(ctx, sizeInBytes, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{})
+	resp, err := blob.Create(ctx, sizeInBytes, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier)
 
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.StatusCode(), chk.Equals, 201)

--- a/azblob/zt_url_blob_test.go
+++ b/azblob/zt_url_blob_test.go
@@ -94,7 +94,7 @@ func (s *aztestsSuite) TestBlobStartCopyDestEmpty(c *chk.C) {
 	blobURL, _ := createNewBlockBlob(c, containerURL)
 	copyBlobURL, _ := getBlockBlobURL(c, containerURL)
 
-	blobCopyResponse, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{}, BlobAccessConditions{})
+	blobCopyResponse, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	waitForCopy(c, copyBlobURL, blobCopyResponse)
 
@@ -115,7 +115,7 @@ func (s *aztestsSuite) TestBlobStartCopyMetadata(c *chk.C) {
 	blobURL, _ := createNewBlockBlob(c, containerURL)
 	copyBlobURL, _ := getBlockBlobURL(c, containerURL)
 
-	resp, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), basicMetadata, ModifiedAccessConditions{}, BlobAccessConditions{})
+	resp, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), basicMetadata, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	waitForCopy(c, copyBlobURL, resp)
 
@@ -136,7 +136,7 @@ func (s *aztestsSuite) TestBlobStartCopyMetadataNil(c *chk.C) {
 		basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
-	resp, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{}, BlobAccessConditions{})
+	resp, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	waitForCopy(c, copyBlobURL, resp)
@@ -158,7 +158,7 @@ func (s *aztestsSuite) TestBlobStartCopyMetadataEmpty(c *chk.C) {
 		basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
-	resp, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{})
+	resp, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	waitForCopy(c, copyBlobURL, resp)
@@ -175,7 +175,7 @@ func (s *aztestsSuite) TestBlobStartCopyMetadataInvalidField(c *chk.C) {
 	blobURL, _ := createNewBlockBlob(c, containerURL)
 	copyBlobURL, _ := getBlockBlobURL(c, containerURL)
 
-	_, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), Metadata{"I nvalid.": "bar"}, ModifiedAccessConditions{}, BlobAccessConditions{})
+	_, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), Metadata{"I nvalid.": "bar"}, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.NotNil)
 	c.Assert(strings.Contains(err.Error(), invalidHeaderErrorSubstring), chk.Equals, true)
 }
@@ -187,7 +187,7 @@ func (s *aztestsSuite) TestBlobStartCopySourceNonExistant(c *chk.C) {
 	blobURL, _ := getBlockBlobURL(c, containerURL)
 	copyBlobURL, _ := getBlockBlobURL(c, containerURL)
 
-	_, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{}, BlobAccessConditions{})
+	_, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeBlobNotFound)
 }
 
@@ -211,7 +211,7 @@ func (s *aztestsSuite) TestBlobStartCopySourcePrivate(c *chk.C) {
 	if bsu.String() == bsu2.String() {
 		c.Skip("Test not valid because primary and secondary accounts are the same")
 	}
-	_, err = copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{}, BlobAccessConditions{})
+	_, err = copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeCannotVerifyCopySource)
 }
 
@@ -250,7 +250,7 @@ func (s *aztestsSuite) TestBlobStartCopyUsingSASSrc(c *chk.C) {
 	defer deleteContainer(c, copyContainerURL)
 	copyBlobURL, _ := getBlockBlobURL(c, copyContainerURL)
 
-	resp, err := copyBlobURL.StartCopyFromURL(ctx, sasURL, nil, ModifiedAccessConditions{}, BlobAccessConditions{})
+	resp, err := copyBlobURL.StartCopyFromURL(ctx, sasURL, nil, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	waitForCopy(c, copyBlobURL, resp)
@@ -321,7 +321,7 @@ func (s *aztestsSuite) TestBlobStartCopyUsingSASDest(c *chk.C) {
 	srcBlobWithSasURL := blobURL.URL()
 	srcBlobWithSasURL.RawQuery = queryParams.Encode()
 
-	resp, err := anonBlobURL.StartCopyFromURL(ctx, srcBlobWithSasURL, nil, ModifiedAccessConditions{}, BlobAccessConditions{})
+	resp, err := anonBlobURL.StartCopyFromURL(ctx, srcBlobWithSasURL, nil, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	// Allow copy to happen
@@ -348,7 +348,7 @@ func (s *aztestsSuite) TestBlobStartCopySourceIfModifiedSinceTrue(c *chk.C) {
 	destBlobURL, _ := getBlockBlobURL(c, containerURL)
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), basicMetadata,
 		ModifiedAccessConditions{IfModifiedSince: currentTime},
-		BlobAccessConditions{})
+		BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := destBlobURL.GetProperties(ctx, BlobAccessConditions{})
@@ -367,7 +367,7 @@ func (s *aztestsSuite) TestBlobStartCopySourceIfModifiedSinceFalse(c *chk.C) {
 	destBlobURL, _ := getBlockBlobURL(c, containerURL)
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil,
 		ModifiedAccessConditions{IfModifiedSince: currentTime},
-		BlobAccessConditions{})
+		BlobAccessConditions{}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeSourceConditionNotMet)
 }
 
@@ -382,7 +382,7 @@ func (s *aztestsSuite) TestBlobStartCopySourceIfUnmodifiedSinceTrue(c *chk.C) {
 	destBlobURL, _ := getBlockBlobURL(c, containerURL)
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), basicMetadata,
 		ModifiedAccessConditions{IfUnmodifiedSince: currentTime},
-		BlobAccessConditions{})
+		BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := destBlobURL.GetProperties(ctx, BlobAccessConditions{})
@@ -401,7 +401,7 @@ func (s *aztestsSuite) TestBlobStartCopySourceIfUnmodifiedSinceFalse(c *chk.C) {
 	destBlobURL, _ := getBlockBlobURL(c, containerURL)
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil,
 		ModifiedAccessConditions{IfUnmodifiedSince: currentTime},
-		BlobAccessConditions{})
+		BlobAccessConditions{}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeSourceConditionNotMet)
 }
 
@@ -418,7 +418,7 @@ func (s *aztestsSuite) TestBlobStartCopySourceIfMatchTrue(c *chk.C) {
 	destBlobURL, _ := getBlockBlobURL(c, containerURL)
 	_, err = destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), basicMetadata,
 		ModifiedAccessConditions{IfMatch: etag},
-		BlobAccessConditions{})
+		BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp2, err := destBlobURL.GetProperties(ctx, BlobAccessConditions{})
@@ -435,7 +435,7 @@ func (s *aztestsSuite) TestBlobStartCopySourceIfMatchFalse(c *chk.C) {
 	destBlobURL, _ := getBlockBlobURL(c, containerURL)
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), basicMetadata,
 		ModifiedAccessConditions{IfMatch: "a"},
-		BlobAccessConditions{})
+		BlobAccessConditions{}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeSourceConditionNotMet)
 }
 
@@ -448,7 +448,7 @@ func (s *aztestsSuite) TestBlobStartCopySourceIfNoneMatchTrue(c *chk.C) {
 	destBlobURL, _ := getBlockBlobURL(c, containerURL)
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), basicMetadata,
 		ModifiedAccessConditions{IfNoneMatch: "a"},
-		BlobAccessConditions{})
+		BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp2, err := destBlobURL.GetProperties(ctx, BlobAccessConditions{})
@@ -469,7 +469,7 @@ func (s *aztestsSuite) TestBlobStartCopySourceIfNoneMatchFalse(c *chk.C) {
 	destBlobURL, _ := getBlockBlobURL(c, containerURL)
 	_, err = destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil,
 		ModifiedAccessConditions{IfNoneMatch: etag},
-		BlobAccessConditions{})
+		BlobAccessConditions{}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeSourceConditionNotMet)
 }
 
@@ -483,7 +483,7 @@ func (s *aztestsSuite) TestBlobStartCopyDestIfModifiedSinceTrue(c *chk.C) {
 	destBlobURL, _ := createNewBlockBlob(c, containerURL) // The blob must exist to have a last-modified time
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), basicMetadata,
 		ModifiedAccessConditions{},
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := destBlobURL.GetProperties(ctx, BlobAccessConditions{})
@@ -502,7 +502,7 @@ func (s *aztestsSuite) TestBlobStartCopyDestIfModifiedSinceFalse(c *chk.C) {
 
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil,
 		ModifiedAccessConditions{},
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeTargetConditionNotMet)
 }
 
@@ -517,7 +517,7 @@ func (s *aztestsSuite) TestBlobStartCopyDestIfUnmodifiedSinceTrue(c *chk.C) {
 
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), basicMetadata,
 		ModifiedAccessConditions{},
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := destBlobURL.GetProperties(ctx, BlobAccessConditions{})
@@ -536,7 +536,7 @@ func (s *aztestsSuite) TestBlobStartCopyDestIfUnmodifiedSinceFalse(c *chk.C) {
 
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil,
 		ModifiedAccessConditions{},
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeTargetConditionNotMet)
 }
 
@@ -552,7 +552,7 @@ func (s *aztestsSuite) TestBlobStartCopyDestIfMatchTrue(c *chk.C) {
 
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), basicMetadata,
 		ModifiedAccessConditions{},
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: etag}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: etag}}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err = destBlobURL.GetProperties(ctx, BlobAccessConditions{})
@@ -573,7 +573,7 @@ func (s *aztestsSuite) TestBlobStartCopyDestIfMatchFalse(c *chk.C) {
 	destBlobURL.SetMetadata(ctx, nil, BlobAccessConditions{}) // SetMetadata chances the blob's etag
 
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{},
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: etag}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: etag}}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeTargetConditionNotMet)
 }
 
@@ -590,7 +590,7 @@ func (s *aztestsSuite) TestBlobStartCopyDestIfNoneMatchTrue(c *chk.C) {
 	destBlobURL.SetMetadata(ctx, nil, BlobAccessConditions{}) // SetMetadata chances the blob's etag
 
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), basicMetadata, ModifiedAccessConditions{},
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: etag}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: etag}}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err = destBlobURL.GetProperties(ctx, BlobAccessConditions{})
@@ -609,7 +609,7 @@ func (s *aztestsSuite) TestBlobStartCopyDestIfNoneMatchFalse(c *chk.C) {
 	etag := resp.ETag()
 
 	_, err := destBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{},
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: etag}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: etag}}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeTargetConditionNotMet)
 }
 
@@ -641,7 +641,7 @@ func (s *aztestsSuite) TestBlobAbortCopyInProgress(c *chk.C) {
 
 	defer deleteContainer(c, copyContainerURL)
 
-	resp, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{}, BlobAccessConditions{})
+	resp, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.CopyStatus(), chk.Equals, CopyStatusPending)
 

--- a/azblob/zt_url_blob_test.go
+++ b/azblob/zt_url_blob_test.go
@@ -133,7 +133,7 @@ func (s *aztestsSuite) TestBlobStartCopyMetadataNil(c *chk.C) {
 
 	// Have the destination start with metadata so we ensure the nil metadata passed later takes effect
 	_, err := copyBlobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{},
-		basicMetadata, BlobAccessConditions{})
+		basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), nil, ModifiedAccessConditions{}, BlobAccessConditions{})
@@ -155,7 +155,7 @@ func (s *aztestsSuite) TestBlobStartCopyMetadataEmpty(c *chk.C) {
 
 	// Have the destination start with metadata so we ensure the empty metadata passed later takes effect
 	_, err := copyBlobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{},
-		basicMetadata, BlobAccessConditions{})
+		basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := copyBlobURL.StartCopyFromURL(ctx, blobURL.URL(), Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{})
@@ -625,7 +625,7 @@ func (s *aztestsSuite) TestBlobAbortCopyInProgress(c *chk.C) {
 	for i := range blobData {
 		blobData[i] = byte('a' + i%26)
 	}
-	_, err := blobURL.Upload(ctx, bytes.NewReader(blobData), BlobHTTPHeaders{}, nil, BlobAccessConditions{})
+	_, err := blobURL.Upload(ctx, bytes.NewReader(blobData), BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	containerURL.SetAccessPolicy(ctx, PublicAccessBlob, nil, ContainerAccessConditions{}) // So that we don't have to create a SAS
 
@@ -1970,4 +1970,3 @@ func (s *aztestsSuite) TestDownloadBlockBlobUnexpectedEOF(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 	c.Assert(buf, chk.DeepEquals, []byte(blockBlobDefaultData))
 }
-

--- a/azblob/zt_url_block_blob_test.go
+++ b/azblob/zt_url_block_blob_test.go
@@ -88,7 +88,7 @@ func (s *aztestsSuite) TestStageBlockFromURL(c *chk.C) {
 	destBlob := container.NewBlockBlobURL(generateBlobName())
 
 	// Prepare source blob for copy.
-	uploadSrcResp, err := srcBlob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	uploadSrcResp, err := srcBlob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadSrcResp.Response().StatusCode, chk.Equals, 201)
 
@@ -163,7 +163,7 @@ func (s *aztestsSuite) TestCopyBlockBlobFromURL(c *chk.C) {
 	destBlob := container.NewBlockBlobURL(generateBlobName())
 
 	// Prepare source blob for copy.
-	uploadSrcResp, err := srcBlob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	uploadSrcResp, err := srcBlob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadSrcResp.Response().StatusCode, chk.Equals, 201)
 
@@ -231,7 +231,7 @@ func (s *aztestsSuite) TestBlobSASQueryParamOverrideResponseHeaders(c *chk.C) {
 	ctx := context.Background() // Use default Background context
 	blob := container.NewBlockBlobURL(generateBlobName())
 
-	uploadResp, err := blob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	uploadResp, err := blob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadResp.Response().StatusCode, chk.Equals, 201)
 
@@ -303,7 +303,7 @@ func (s *aztestsSuite) TestBlobPutBlobNonEmptyBody(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getBlockBlobURL(c, containerURL)
 
-	_, err := blobURL.Upload(ctx, strings.NewReader(blockBlobDefaultData), BlobHTTPHeaders{}, nil, BlobAccessConditions{})
+	_, err := blobURL.Upload(ctx, strings.NewReader(blockBlobDefaultData), BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false)
@@ -318,7 +318,7 @@ func (s *aztestsSuite) TestBlobPutBlobHTTPHeaders(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getBlockBlobURL(c, containerURL)
 
-	_, err := blobURL.Upload(ctx, bytes.NewReader(nil), basicHeaders, nil, BlobAccessConditions{})
+	_, err := blobURL.Upload(ctx, bytes.NewReader(nil), basicHeaders, nil, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
@@ -334,7 +334,7 @@ func (s *aztestsSuite) TestBlobPutBlobMetadataNotEmpty(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getBlockBlobURL(c, containerURL)
 
-	_, err := blobURL.Upload(ctx, bytes.NewReader(nil), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{})
+	_, err := blobURL.Upload(ctx, bytes.NewReader(nil), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
@@ -348,7 +348,7 @@ func (s *aztestsSuite) TestBlobPutBlobMetadataEmpty(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getBlockBlobURL(c, containerURL)
 
-	_, err := blobURL.Upload(ctx, bytes.NewReader(nil), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	_, err := blobURL.Upload(ctx, bytes.NewReader(nil), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
@@ -362,7 +362,7 @@ func (s *aztestsSuite) TestBlobPutBlobMetadataInvalid(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getBlockBlobURL(c, containerURL)
 
-	_, err := blobURL.Upload(ctx, nil, BlobHTTPHeaders{}, Metadata{"In valid!": "bar"}, BlobAccessConditions{})
+	_, err := blobURL.Upload(ctx, nil, BlobHTTPHeaders{}, Metadata{"In valid!": "bar"}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(strings.Contains(err.Error(), validationErrorSubstring), chk.Equals, true)
 }
 
@@ -375,7 +375,7 @@ func (s *aztestsSuite) TestBlobPutBlobIfModifiedSinceTrue(c *chk.C) {
 	currentTime := getRelativeTimeGMT(-10)
 
 	_, err := blobURL.Upload(ctx, bytes.NewReader(nil), BlobHTTPHeaders{}, nil,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	validateUpload(c, blobURL)
@@ -390,7 +390,7 @@ func (s *aztestsSuite) TestBlobPutBlobIfModifiedSinceFalse(c *chk.C) {
 	currentTime := getRelativeTimeGMT(10)
 
 	_, err := blobURL.Upload(ctx, bytes.NewReader(nil), BlobHTTPHeaders{}, nil,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -403,7 +403,7 @@ func (s *aztestsSuite) TestBlobPutBlobIfUnmodifiedSinceTrue(c *chk.C) {
 	currentTime := getRelativeTimeGMT(10)
 
 	_, err := blobURL.Upload(ctx, bytes.NewReader(nil), BlobHTTPHeaders{}, nil,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	validateUpload(c, blobURL)
@@ -418,7 +418,7 @@ func (s *aztestsSuite) TestBlobPutBlobIfUnmodifiedSinceFalse(c *chk.C) {
 	currentTime := getRelativeTimeGMT(-10)
 
 	_, err := blobURL.Upload(ctx, bytes.NewReader(nil), BlobHTTPHeaders{}, nil,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -432,7 +432,7 @@ func (s *aztestsSuite) TestBlobPutBlobIfMatchTrue(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 
 	_, err = blobURL.Upload(ctx, bytes.NewReader(nil), BlobHTTPHeaders{}, nil,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	validateUpload(c, blobURL)
@@ -448,7 +448,7 @@ func (s *aztestsSuite) TestBlobPutBlobIfMatchFalse(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 
 	_, err = blobURL.Upload(ctx, bytes.NewReader(nil), BlobHTTPHeaders{}, nil,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: ETag("garbage")}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: ETag("garbage")}}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -462,7 +462,7 @@ func (s *aztestsSuite) TestBlobPutBlobIfNoneMatchTrue(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 
 	_, err = blobURL.Upload(ctx, bytes.NewReader(nil), BlobHTTPHeaders{}, nil,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETag("garbage")}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETag("garbage")}}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	validateUpload(c, blobURL)
@@ -478,7 +478,7 @@ func (s *aztestsSuite) TestBlobPutBlobIfNoneMatchFalse(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 
 	_, err = blobURL.Upload(ctx, bytes.NewReader(nil), BlobHTTPHeaders{}, nil,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}}, DefaultAccessTier)
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -899,3 +899,18 @@ func (s *aztestsSuite) TestBlobPutBlockListModifyBlob(c *chk.C) {
 	c.Assert(resp.UncommittedBlocks, chk.HasLen, 0)
 }
 
+func (s *aztestsSuite) TestSetTierOnBlobUpload(c *chk.C) {
+	bsu := getBSU()
+	containerURL, _ := createNewContainer(c, bsu)
+	defer deleteContainer(c, containerURL)
+	for _, val := range []AccessTierType{AccessTierArchive, AccessTierCool, AccessTierHot} {
+		blobURL, _ := getBlockBlobURL(c, containerURL)
+
+		_, err := blobURL.Upload(ctx, strings.NewReader("Test Data"), basicHeaders, nil, BlobAccessConditions{}, val)
+		c.Assert(err, chk.IsNil)
+
+		resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
+		c.Assert(err, chk.IsNil)
+		c.Assert(resp.AccessTier(), chk.Equals, string(val))
+	}
+}

--- a/azblob/zt_url_container_test.go
+++ b/azblob/zt_url_container_test.go
@@ -383,7 +383,7 @@ func (s *aztestsSuite) TestContainerListBlobsIncludeTypeCopy(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, blobName := createNewBlockBlob(c, containerURL)
 	blobCopyURL, blobCopyName := createBlockBlobWithPrefix(c, containerURL, "copy")
-	_, err := blobCopyURL.StartCopyFromURL(ctx, blobURL.URL(), Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{})
+	_, err := blobCopyURL.StartCopyFromURL(ctx, blobURL.URL(), Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := containerURL.ListBlobsFlatSegment(ctx, Marker{},
@@ -457,7 +457,7 @@ func testContainerListBlobsIncludeMultipleImpl(c *chk.C, bsu ServiceURL) error {
 	_, err := blobURL.CreateSnapshot(ctx, Metadata{}, BlobAccessConditions{})
 	c.Assert(err, chk.IsNil)
 	blobURL2, _ := createBlockBlobWithPrefix(c, containerURL, "copy")
-	resp2, err := blobURL2.StartCopyFromURL(ctx, blobURL.URL(), Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{})
+	resp2, err := blobURL2.StartCopyFromURL(ctx, blobURL.URL(), Metadata{}, ModifiedAccessConditions{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	waitForCopy(c, blobURL2, resp2)
 	blobURL3, _ := createBlockBlobWithPrefix(c, containerURL, "deleted")

--- a/azblob/zt_url_container_test.go
+++ b/azblob/zt_url_container_test.go
@@ -124,8 +124,7 @@ func (s *aztestsSuite) TestContainerCreateAccessContainer(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 
 	blobURL := containerURL.NewBlockBlobURL(blobPrefix)
-	blobURL.Upload(ctx, bytes.NewReader([]byte("Content")), BlobHTTPHeaders{},
-		basicMetadata, BlobAccessConditions{})
+	blobURL.Upload(ctx, bytes.NewReader([]byte("Content")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 
 	// Anonymous enumeration should be valid with container access
 	containerURL2 := NewContainerURL(containerURL.URL(), NewPipeline(NewAnonymousCredential(), PipelineOptions{}))
@@ -150,8 +149,7 @@ func (s *aztestsSuite) TestContainerCreateAccessBlob(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 
 	blobURL := containerURL.NewBlockBlobURL(blobPrefix)
-	blobURL.Upload(ctx, bytes.NewReader([]byte("Content")), BlobHTTPHeaders{},
-		basicMetadata, BlobAccessConditions{})
+	blobURL.Upload(ctx, bytes.NewReader([]byte("Content")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 
 	// Reference the same container URL but with anonymous credentials
 	containerURL2 := NewContainerURL(containerURL.URL(), NewPipeline(NewAnonymousCredential(), PipelineOptions{}))
@@ -173,8 +171,7 @@ func (s *aztestsSuite) TestContainerCreateAccessNone(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 
 	blobURL := containerURL.NewBlockBlobURL(blobPrefix)
-	blobURL.Upload(ctx, bytes.NewReader([]byte("Content")), BlobHTTPHeaders{},
-		basicMetadata, BlobAccessConditions{})
+	blobURL.Upload(ctx, bytes.NewReader([]byte("Content")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier)
 
 	// Reference the same container URL but with anonymous credentials
 	containerURL2 := NewContainerURL(containerURL.URL(), NewPipeline(NewAnonymousCredential(), PipelineOptions{}))

--- a/azblob/zt_url_page_blob_test.go
+++ b/azblob/zt_url_page_blob_test.go
@@ -293,7 +293,7 @@ func (s *aztestsSuite) TestBlobCreatePageSizeInvalid(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.Create(ctx, 1, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{})
+	_, err := blobURL.Create(ctx, 1, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier)
 	validateStorageError(c, err, ServiceCodeInvalidHeaderValue)
 }
 
@@ -303,7 +303,7 @@ func (s *aztestsSuite) TestBlobCreatePageSequenceInvalid(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, -1, BlobHTTPHeaders{}, nil, BlobAccessConditions{})
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, -1, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier)
 	c.Assert(err, chk.Not(chk.IsNil))
 }
 
@@ -313,7 +313,7 @@ func (s *aztestsSuite) TestBlobCreatePageMetadataNonEmpty(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{})
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultPremiumBlobAccessTier)
 
 	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
 	c.Assert(err, chk.IsNil)
@@ -326,7 +326,7 @@ func (s *aztestsSuite) TestBlobCreatePageMetadataEmpty(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultPremiumBlobAccessTier)
 
 	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
 	c.Assert(err, chk.IsNil)
@@ -339,7 +339,7 @@ func (s *aztestsSuite) TestBlobCreatePageMetadataInvalid(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, Metadata{"In valid1": "bar"}, BlobAccessConditions{})
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, Metadata{"In valid1": "bar"}, BlobAccessConditions{}, PremiumPageBlobAccessTierNone)
 	c.Assert(strings.Contains(err.Error(), invalidHeaderErrorSubstring), chk.Equals, true)
 
 }
@@ -350,7 +350,7 @@ func (s *aztestsSuite) TestBlobCreatePageHTTPHeaders(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, basicHeaders, nil, BlobAccessConditions{})
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, basicHeaders, nil, BlobAccessConditions{}, PremiumPageBlobAccessTierNone)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
@@ -374,7 +374,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfModifiedSinceTrue(c *chk.C) {
 	currentTime := getRelativeTimeGMT(-10)
 
 	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, DefaultPremiumBlobAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	validatePageBlobPut(c, blobURL)
@@ -389,7 +389,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfModifiedSinceFalse(c *chk.C) {
 	currentTime := getRelativeTimeGMT(10)
 
 	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, DefaultPremiumBlobAccessTier)
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -402,7 +402,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfUnmodifiedSinceTrue(c *chk.C) {
 	currentTime := getRelativeTimeGMT(10)
 
 	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, DefaultPremiumBlobAccessTier)
 	c.Assert(err, chk.IsNil)
 
 	validatePageBlobPut(c, blobURL)
@@ -417,7 +417,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfUnmodifiedSinceFalse(c *chk.C) {
 	currentTime := getRelativeTimeGMT(-10)
 
 	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, DefaultPremiumBlobAccessTier)
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -430,7 +430,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfMatchTrue(c *chk.C) {
 	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
 
 	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}}, PremiumPageBlobAccessTierNone)
 	c.Assert(err, chk.IsNil)
 
 	validatePageBlobPut(c, blobURL)
@@ -443,7 +443,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfMatchFalse(c *chk.C) {
 	blobURL, _ := createNewPageBlob(c, containerURL) // Originally created without metadata
 
 	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: ETag("garbage")}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: ETag("garbage")}}, PremiumPageBlobAccessTierNone)
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -454,7 +454,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfNoneMatchTrue(c *chk.C) {
 	blobURL, _ := createNewPageBlob(c, containerURL) // Originally created without metadata
 
 	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETag("garbage")}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETag("garbage")}}, PremiumPageBlobAccessTierNone)
 	c.Assert(err, chk.IsNil)
 
 	validatePageBlobPut(c, blobURL)
@@ -469,7 +469,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfNoneMatchFalse(c *chk.C) {
 	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
 
 	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}})
+		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}}, DefaultPremiumBlobAccessTier)
 
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }

--- a/azblob/zt_url_service_test.go
+++ b/azblob/zt_url_service_test.go
@@ -27,7 +27,7 @@ func (s *aztestsSuite) TestGetAccountInfo(c *chk.C) {
 
 	// test on a block blob URL. They all call the same thing on the base URL, so only one test is needed for that.
 	bbURL := cURL.NewBlockBlobURL(generateBlobName())
-	_, err = bbURL.Upload(ctx, strings.NewReader("blah"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	_, err = bbURL.Upload(ctx, strings.NewReader("blah"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	c.Assert(err, chk.IsNil)
 	bAccInfo, err := bbURL.GetAccountInfo(ctx)
 	c.Assert(err, chk.IsNil)

--- a/azblob/zt_user_delegation_sas_test.go
+++ b/azblob/zt_user_delegation_sas_test.go
@@ -52,7 +52,7 @@ func (s *aztestsSuite) TestUserDelegationSASContainer(c *chk.C) {
 	cSASURL := NewContainerURL(cURL, p)
 
 	bblob := cSASURL.NewBlockBlobURL("test")
-	_, err = bblob.Upload(ctx, strings.NewReader("hello world!"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{})
+	_, err = bblob.Upload(ctx, strings.NewReader("hello world!"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func (s *aztestsSuite) TestUserDelegationSASBlob(c *chk.C) {
 		c.Fatal(err)
 	}
 	data := "Hello World!"
-	_, err = blobURL.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{})
+	_, err = blobURL.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier)
 	if err != nil {
 		c.Fatal(err)
 	}


### PR DESCRIPTION
Instead of invoking `setTier() `method separately, added support to set tier of  blob at the time of upload/copy. This will facilitate faster performance. 

Changed the function signature of `Upload()` and introduced new parameter tier of type `AccessTierType` . 