### PR TITLE
Consider 502 as a temporary error

### DIFF
--- a/azblob/zc_storage_error.go
+++ b/azblob/zc_storage_error.go
@@ -79,7 +79,7 @@ func (e *storageError) Error() string {
 // Temporary returns true if the error occurred due to a temporary condition (including an HTTP status of 500 or 503).
 func (e *storageError) Temporary() bool {
 	if e.response != nil {
-		if (e.response.StatusCode == http.StatusInternalServerError) || (e.response.StatusCode == http.StatusServiceUnavailable) {
+		if (e.response.StatusCode == http.StatusInternalServerError) || (e.response.StatusCode == http.StatusServiceUnavailable) || (e.response.StatusCode == http.StatusBadGateway) {
 			return true
 		}
 	}


### PR DESCRIPTION
From MDN:

> The HyperText Transfer Protocol (HTTP) 502 Bad Gateway server error response code indicates that the server, while acting as a gateway or proxy, received an invalid response from the upstream server.


Since the proxy might be misbehaving, it can be seen as a temporary error.