### PR TITLE
Adding method GetManagedDiskPageRangesDiff() which was implemented in…

### DIFF
--- a/azblob/url_page_blob.go
+++ b/azblob/url_page_blob.go
@@ -141,6 +141,20 @@ func (pb PageBlobURL) GetPageRanges(ctx context.Context, offset int64, count int
 		nil)
 }
 
+// GetManagedDiskPageRangesDiff gets the collection of page ranges that differ between a specified snapshot and this page blob representing managed disk.
+// For more information, see https://docs.microsoft.com/rest/api/storageservices/get-page-ranges.
+func (pb PageBlobURL) GetManagedDiskPageRangesDiff(ctx context.Context, offset int64, count int64, prevSnapshot *string, prevSnapshotURL *string, ac BlobAccessConditions) (*PageList, error) {
+	ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag := ac.ModifiedAccessConditions.pointers()
+
+	return pb.pbClient.GetPageRangesDiff(ctx, nil, nil, prevSnapshot,
+		prevSnapshotURL, // Get managed disk diff
+		httpRange{offset: offset, count: count}.pointers(),
+		ac.LeaseAccessConditions.pointers(),
+		ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag,
+		nil, // Blob ifTags
+		nil)
+}
+
 // GetPageRangesDiff gets the collection of page ranges that differ between a specified snapshot and this page blob.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/get-page-ranges.
 func (pb PageBlobURL) GetPageRangesDiff(ctx context.Context, offset int64, count int64, prevSnapshot string, ac BlobAccessConditions) (*PageList, error) {


### PR DESCRIPTION
Hope I'm not missing anything but GetManagedDiskPageRangesDiff() which was  implemented in .Net SDK is missing in azure-storage-blob-go/azblob ...So adding corresponding method into golang SDK ...

For details on GetManagedDiskPageRangesDiff() in .Net SDK see
https://docs.microsoft.com/en-us/dotnet/api/azure.storage.blobs.specialized.pageblobclient.getmanageddiskpagerangesdiff?view=azure-dotnet

Even though I see a pbClient.GetPageRangesDiff() function (in dev branch) that accepts prevSnapshotURl parameter the pbClient is not exported /not accessible outside of the package .. so this function cannot be called from outside .  Exporting pbClient would be an option but I think having consistency b/w  golang and .Net SDKs is a better choice ...

0.2   