### PR TITLE
#7507887 #7507908 [Go][Blob] Support CPK-N/CPK-V

### DIFF
--- a/azblob/chunkwriting_test.go
+++ b/azblob/chunkwriting_test.go
@@ -37,7 +37,7 @@ func newFakeBlockWriter() *fakeBlockWriter {
 	return f
 }
 
-func (f *fakeBlockWriter) StageBlock(ctx context.Context, blockID string, r io.ReadSeeker, cond LeaseAccessConditions, md5 []byte) (*BlockBlobStageBlockResponse, error) {
+func (f *fakeBlockWriter) StageBlock(ctx context.Context, blockID string, r io.ReadSeeker, cond LeaseAccessConditions, md5 []byte, cpk ClientProvidedKeyOptions) (*BlockBlobStageBlockResponse, error) {
 	n := atomic.AddInt32(&f.block, 1)
 	if n == f.errOnBlock {
 		return nil, io.ErrNoProgress
@@ -58,7 +58,7 @@ func (f *fakeBlockWriter) StageBlock(ctx context.Context, blockID string, r io.R
 	return &BlockBlobStageBlockResponse{}, nil
 }
 
-func (f *fakeBlockWriter) CommitBlockList(ctx context.Context, blockIDs []string, headers BlobHTTPHeaders, meta Metadata, access BlobAccessConditions, tier AccessTierType, blobTagsMap BlobTagsMap) (*BlockBlobCommitBlockListResponse, error) {
+func (f *fakeBlockWriter) CommitBlockList(ctx context.Context, blockIDs []string, headers BlobHTTPHeaders, meta Metadata, access BlobAccessConditions, tier AccessTierType, blobTagsMap BlobTagsMap, options ClientProvidedKeyOptions) (*BlockBlobCommitBlockListResponse, error) {
 	dst, err := os.OpenFile(filepath.Join(f.path, finalFileName), os.O_CREATE+os.O_WRONLY, 0600)
 	if err != nil {
 		return nil, err

--- a/azblob/parsing_urls.go
+++ b/azblob/parsing_urls.go
@@ -1,7 +1,6 @@
 package azblob
 
 import (
-	"errors"
 	"net"
 	"net/url"
 	"strings"
@@ -134,11 +133,6 @@ func (up BlobURLParts) URL() url.URL {
 	}
 
 	rawQuery := up.UnparsedParams
-
-	// Check: Both snapshot and version id cannot be present in the request URL.
-	if up.Snapshot != "" && up.VersionID != "" {
-		errors.New("Snapshot and versioning cannot be enabled simultaneously")
-	}
 
 	//If no snapshot is initially provided, fill it in from the SAS query properties to help the user
 	if up.Snapshot == "" && !up.SAS.snapshotTime.IsZero() {

--- a/azblob/request_common.go
+++ b/azblob/request_common.go
@@ -6,11 +6,22 @@ package azblob
 // must be established to transfer the key.
 // Note: Azure Storage does not store or manage customer provided encryption keys. Keys are securely discarded
 // as soon as possible after they’ve been used to encrypt or decrypt the blob data.
+// https://docs.microsoft.com/en-us/azure/storage/common/storage-service-encryption
+// https://docs.microsoft.com/en-us/azure/storage/common/customer-managed-keys-overview
 type ClientProvidedKeyOptions struct {
-	EncryptionKey       *string                 // A Base64-encoded AES-256 encryption key value.
-	EncryptionKeySha256 *string                 // The Base64-encoded SHA256 of the encryption key.
-	EncryptionAlgorithm EncryptionAlgorithmType // Specifies the algorithm to use when encrypting data using the given key. Must be AES256.
-	EncryptionScope     *string
+	// A Base64-encoded AES-256 encryption key value.
+	EncryptionKey *string
+
+	// The Base64-encoded SHA256 of the encryption key.
+	EncryptionKeySha256 *string
+
+	// Specifies the algorithm to use when encrypting data using the given key. Must be AES256.
+	EncryptionAlgorithm EncryptionAlgorithmType
+
+	// Specifies the name of the encryption scope to use to encrypt the data provided in the request
+	// https://docs.microsoft.com/en-us/azure/storage/blobs/encryption-scope-overview
+	// https://docs.microsoft.com/en-us/azure/key-vault/general/overview
+	EncryptionScope *string
 }
 
 // NewClientProvidedKeyOptions function.

--- a/azblob/request_common.go
+++ b/azblob/request_common.go
@@ -1,0 +1,22 @@
+package azblob
+
+// ClientProvidedKeyOptions contains headers which may be be specified from service version 2019-02-02
+// or higher to encrypts the data on the service-side with the given key. Use of customer-provided keys
+// must be done over HTTPS. As the encryption key itself is provided in the request, a secure connection
+// must be established to transfer the key.
+// Note: Azure Storage does not store or manage customer provided encryption keys. Keys are securely discarded
+// as soon as possible after they’ve been used to encrypt or decrypt the blob data.
+type ClientProvidedKeyOptions struct {
+	EncryptionKey       *string                 // A Base64-encoded AES-256 encryption key value.
+	EncryptionKeySha256 *string                 // The Base64-encoded SHA256 of the encryption key.
+	EncryptionAlgorithm EncryptionAlgorithmType // Specifies the algorithm to use when encrypting data using the given key. Must be AES256.
+	EncryptionScope     *string
+}
+
+// NewClientProvidedKeyOptions function.
+// By default the value of encryption algorithm params is "AES256" for service version 2019-02-02 or higher.
+func NewClientProvidedKeyOptions(ek *string, eksha256 *string, es *string) (cpk ClientProvidedKeyOptions) {
+	cpk = ClientProvidedKeyOptions{}
+	cpk.EncryptionKey, cpk.EncryptionKeySha256, cpk.EncryptionAlgorithm, cpk.EncryptionScope = ek, eksha256, EncryptionAlgorithmAES256, es
+	return cpk
+}

--- a/azblob/service_codes_blob.go
+++ b/azblob/service_codes_blob.go
@@ -61,8 +61,11 @@ const (
 	// ServiceCodeIncrementalCopyBlobMismatch means the specified source blob is different than the copy source of the existing incremental copy blob.
 	ServiceCodeIncrementalCopyBlobMismatch ServiceCodeType = "IncrementalCopyBlobMismatch"
 
-	// ServiceCodeIncrementalCopyOfEralierVersionSnapshotNotAllowed means the specified snapshot is earlier than the last snapshot copied into the incremental copy blob.
-	ServiceCodeIncrementalCopyOfEralierVersionSnapshotNotAllowed ServiceCodeType = "IncrementalCopyOfEralierVersionSnapshotNotAllowed"
+	// ServiceCodeFeatureEncryptionMismatch means the given customer specified encryption does not match the encryption used to encrypt the blob.
+	ServiceCodeFeatureEncryptionMismatch ServiceCodeType = "BlobCustomerSpecifiedEncryptionMismatch"
+
+	// ServiceCodeIncrementalCopyOfEarlierVersionSnapshotNotAllowed means the specified snapshot is earlier than the last snapshot copied into the incremental copy blob.
+	ServiceCodeIncrementalCopyOfEarlierVersionSnapshotNotAllowed ServiceCodeType = "IncrementalCopyOfEarlierVersionSnapshotNotAllowed"
 
 	// ServiceCodeIncrementalCopySourceMustBeSnapshot means the source for incremental copy request must be a snapshot.
 	ServiceCodeIncrementalCopySourceMustBeSnapshot ServiceCodeType = "IncrementalCopySourceMustBeSnapshot"

--- a/azblob/url_page_blob.go
+++ b/azblob/url_page_blob.go
@@ -87,8 +87,8 @@ func (pb PageBlobURL) UploadPages(ctx context.Context, offset int64, body io.Rea
 	return pb.pbClient.UploadPages(ctx, body, count, transactionalMD5, nil, nil,
 		PageRange{Start: offset, End: offset + count - 1}.pointers(),
 		ac.LeaseAccessConditions.pointers(),
-		nil, nil, EncryptionAlgorithmNone, // CPK
-		nil, // CPK-N
+		cpk.EncryptionKey, cpk.EncryptionKeySha256, cpk.EncryptionAlgorithm, // CPK
+		cpk.EncryptionScope, // CPK-N
 		ifSequenceNumberLessThanOrEqual, ifSequenceNumberLessThan, ifSequenceNumberEqual,
 		ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag,
 		nil, // Blob ifTags

--- a/azblob/url_page_blob.go
+++ b/azblob/url_page_blob.go
@@ -14,7 +14,7 @@ const (
 	// PageBlobPageBytes indicates the number of bytes in a page (512).
 	PageBlobPageBytes = 512
 
-	// PageBlobMaxPutPagesBytes indicates the maximum number of bytes that can be sent in a call to PutPage.
+	// PageBlobMaxUploadPagesBytes indicates the maximum number of bytes that can be sent in a call to PutPage.
 	PageBlobMaxUploadPagesBytes = 4 * 1024 * 1024 // 4MB
 )
 
@@ -56,16 +56,16 @@ func (pb PageBlobURL) GetAccountInfo(ctx context.Context) (*BlobGetAccountInfoRe
 	return pb.blobClient.GetAccountInfo(ctx)
 }
 
-// Create creates a page blob of the specified length. Call PutPage to upload data data to a page blob.
+// Create creates a page blob of the specified length. Call PutPage to upload data to a page blob.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/put-blob.
-func (pb PageBlobURL) Create(ctx context.Context, size int64, sequenceNumber int64, h BlobHTTPHeaders, metadata Metadata, ac BlobAccessConditions, tier PremiumPageBlobAccessTierType, blobTagsMap BlobTagsMap) (*PageBlobCreateResponse, error) {
+func (pb PageBlobURL) Create(ctx context.Context, size int64, sequenceNumber int64, h BlobHTTPHeaders, metadata Metadata, ac BlobAccessConditions, tier PremiumPageBlobAccessTierType, blobTagsMap BlobTagsMap, cpk ClientProvidedKeyOptions) (*PageBlobCreateResponse, error) {
 	ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag := ac.ModifiedAccessConditions.pointers()
 	blobTagsString := SerializeBlobTagsHeader(blobTagsMap)
 	return pb.pbClient.Create(ctx, 0, size, nil, tier,
 		&h.ContentType, &h.ContentEncoding, &h.ContentLanguage, h.ContentMD5, &h.CacheControl,
 		metadata, ac.LeaseAccessConditions.pointers(), &h.ContentDisposition,
-		nil, nil, EncryptionAlgorithmNone, // CPK-V
-		nil, // CPK-N
+		cpk.EncryptionKey, cpk.EncryptionKeySha256, cpk.EncryptionAlgorithm, // CPK-V
+		cpk.EncryptionScope, // CPK-N
 		ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag,
 		nil, // Blob tags
 		&sequenceNumber, nil,
@@ -77,7 +77,7 @@ func (pb PageBlobURL) Create(ctx context.Context, size int64, sequenceNumber int
 // This method panics if the stream is not at position 0.
 // Note that the http client closes the body stream after the request is sent to the service.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/put-page.
-func (pb PageBlobURL) UploadPages(ctx context.Context, offset int64, body io.ReadSeeker, ac PageBlobAccessConditions, transactionalMD5 []byte) (*PageBlobUploadPagesResponse, error) {
+func (pb PageBlobURL) UploadPages(ctx context.Context, offset int64, body io.ReadSeeker, ac PageBlobAccessConditions, transactionalMD5 []byte, cpk ClientProvidedKeyOptions) (*PageBlobUploadPagesResponse, error) {
 	count, err := validateSeekableStreamAt0AndGetCount(body)
 	if err != nil {
 		return nil, err
@@ -100,14 +100,14 @@ func (pb PageBlobURL) UploadPages(ctx context.Context, offset int64, body io.Rea
 // The destOffset specifies the start offset of data in page blob will be written to.
 // The count must be a multiple of 512 bytes.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/put-page-from-url.
-func (pb PageBlobURL) UploadPagesFromURL(ctx context.Context, sourceURL url.URL, sourceOffset int64, destOffset int64, count int64, transactionalMD5 []byte, destinationAccessConditions PageBlobAccessConditions, sourceAccessConditions ModifiedAccessConditions) (*PageBlobUploadPagesFromURLResponse, error) {
+func (pb PageBlobURL) UploadPagesFromURL(ctx context.Context, sourceURL url.URL, sourceOffset int64, destOffset int64, count int64, transactionalMD5 []byte, destinationAccessConditions PageBlobAccessConditions, sourceAccessConditions ModifiedAccessConditions, cpk ClientProvidedKeyOptions) (*PageBlobUploadPagesFromURLResponse, error) {
 	ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag := destinationAccessConditions.ModifiedAccessConditions.pointers()
 	sourceIfModifiedSince, sourceIfUnmodifiedSince, sourceIfMatchETag, sourceIfNoneMatchETag := sourceAccessConditions.pointers()
 	ifSequenceNumberLessThanOrEqual, ifSequenceNumberLessThan, ifSequenceNumberEqual := destinationAccessConditions.SequenceNumberAccessConditions.pointers()
 	return pb.pbClient.UploadPagesFromURL(ctx, sourceURL.String(), *PageRange{Start: sourceOffset, End: sourceOffset + count - 1}.pointers(), 0,
 		*PageRange{Start: destOffset, End: destOffset + count - 1}.pointers(), transactionalMD5, nil, nil,
-		nil, nil, EncryptionAlgorithmNone, // CPK-V
-		nil, // CPK-N
+		cpk.EncryptionKey, cpk.EncryptionKeySha256, cpk.EncryptionAlgorithm, // CPK-V
+		cpk.EncryptionScope, // CPK-N
 		destinationAccessConditions.LeaseAccessConditions.pointers(),
 		ifSequenceNumberLessThanOrEqual, ifSequenceNumberLessThan, ifSequenceNumberEqual,
 		ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag,
@@ -117,14 +117,14 @@ func (pb PageBlobURL) UploadPagesFromURL(ctx context.Context, sourceURL url.URL,
 
 // ClearPages frees the specified pages from the page blob.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/put-page.
-func (pb PageBlobURL) ClearPages(ctx context.Context, offset int64, count int64, ac PageBlobAccessConditions) (*PageBlobClearPagesResponse, error) {
+func (pb PageBlobURL) ClearPages(ctx context.Context, offset int64, count int64, ac PageBlobAccessConditions, cpk ClientProvidedKeyOptions) (*PageBlobClearPagesResponse, error) {
 	ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag := ac.ModifiedAccessConditions.pointers()
 	ifSequenceNumberLessThanOrEqual, ifSequenceNumberLessThan, ifSequenceNumberEqual := ac.SequenceNumberAccessConditions.pointers()
 	return pb.pbClient.ClearPages(ctx, 0, nil,
 		PageRange{Start: offset, End: offset + count - 1}.pointers(),
 		ac.LeaseAccessConditions.pointers(),
-		nil, nil, EncryptionAlgorithmNone, // CPK
-		nil, // CPK-N
+		cpk.EncryptionKey, cpk.EncryptionKeySha256, cpk.EncryptionAlgorithm, // CPK
+		cpk.EncryptionScope, // CPK-N
 		ifSequenceNumberLessThanOrEqual, ifSequenceNumberLessThan,
 		ifSequenceNumberEqual, ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag, nil)
 }
@@ -170,15 +170,15 @@ func (pb PageBlobURL) GetPageRangesDiff(ctx context.Context, offset int64, count
 
 // Resize resizes the page blob to the specified size (which must be a multiple of 512).
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/set-blob-properties.
-func (pb PageBlobURL) Resize(ctx context.Context, size int64, ac BlobAccessConditions) (*PageBlobResizeResponse, error) {
+func (pb PageBlobURL) Resize(ctx context.Context, size int64, ac BlobAccessConditions, cpk ClientProvidedKeyOptions) (*PageBlobResizeResponse, error) {
 	ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag := ac.ModifiedAccessConditions.pointers()
 	return pb.pbClient.Resize(ctx, size, nil, ac.LeaseAccessConditions.pointers(),
-		nil, nil, EncryptionAlgorithmNone, // CPK
-		nil, // CPK-N
+		cpk.EncryptionKey, cpk.EncryptionKeySha256, cpk.EncryptionAlgorithm, // CPK
+		cpk.EncryptionScope, // CPK-N
 		ifModifiedSince, ifUnmodifiedSince, ifMatchETag, ifNoneMatchETag, nil)
 }
 
-// SetSequenceNumber sets the page blob's sequence number.
+// UpdateSequenceNumber sets the page blob's sequence number.
 func (pb PageBlobURL) UpdateSequenceNumber(ctx context.Context, action SequenceNumberActionType, sequenceNumber int64,
 	ac BlobAccessConditions) (*PageBlobUpdateSequenceNumberResponse, error) {
 	sn := &sequenceNumber
@@ -191,7 +191,7 @@ func (pb PageBlobURL) UpdateSequenceNumber(ctx context.Context, action SequenceN
 		sn, nil)
 }
 
-// StartIncrementalCopy begins an operation to start an incremental copy from one page blob's snapshot to this page blob.
+// StartCopyIncremental begins an operation to start an incremental copy from one page blob's snapshot to this page blob.
 // The snapshot is copied such that only the differential changes between the previously copied snapshot are transferred to the destination.
 // The copied snapshots are complete copies of the original snapshot and can be read or copied from as usual.
 // For more information, see https://docs.microsoft.com/rest/api/storageservices/incremental-copy-blob and

--- a/azblob/zc_retry_reader.go
+++ b/azblob/zc_retry_reader.go
@@ -56,6 +56,8 @@ type RetryReaderOptions struct {
 	// from the same "thread" (goroutine) as Read.  Concurrent Close calls from other goroutines may instead produce network errors
 	// which will be retried.
 	TreatEarlyCloseAsError bool
+
+	ClientProvidedKeyOptions ClientProvidedKeyOptions
 }
 
 // retryReader implements io.ReaderCloser methods.

--- a/azblob/zc_service_codes_common.go
+++ b/azblob/zc_service_codes_common.go
@@ -114,6 +114,7 @@ const (
 	// ServiceCodeResourceNotFound means the specified resource does not exist (404).
 	ServiceCodeResourceNotFound ServiceCodeType = "ResourceNotFound"
 
+	// ServiceCodeNoAuthenticationInformation means the specified authentication for the resource does not exist (401).
 	ServiceCodeNoAuthenticationInformation ServiceCodeType = "NoAuthenticationInformation"
 
 	// ServiceCodeServerBusy means the server is currently unable to receive requests. Please retry your request or Ingress/egress is over the account limit or operations per second is over the account limit (503).

--- a/azblob/zt_blob_tags_test.go
+++ b/azblob/zt_blob_tags_test.go
@@ -24,7 +24,7 @@ func (s *aztestsSuite) TestSetBlobTags(c *chk.C) {
 		"blob":  "sdk",
 		"sdk":   "go",
 	}
-	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.StatusCode(), chk.Equals, 201)
 	blobSetTagsResponse, err := blobURL.SetTags(ctx, nil, nil, nil, nil, nil, nil, blobTagsMap)
@@ -50,12 +50,12 @@ func (s *aztestsSuite) TestSetBlobTagsWithVID(c *chk.C) {
 		"Python":     "CSharp",
 		"Javascript": "Android",
 	}
-	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.StatusCode(), chk.Equals, 201)
 	versionId1 := blockBlobUploadResp.VersionID()
 
-	blockBlobUploadResp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	blockBlobUploadResp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.StatusCode(), chk.Equals, 201)
 	versionId2 := blockBlobUploadResp.VersionID()
@@ -84,12 +84,12 @@ func (s *aztestsSuite) TestSetBlobTagsWithVID2(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getBlockBlobURL(c, containerURL)
 
-	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.StatusCode(), chk.Equals, 201)
 	versionId1 := blockBlobUploadResp.VersionID()
 
-	blockBlobUploadResp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	blockBlobUploadResp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.StatusCode(), chk.Equals, 201)
 	versionId2 := blockBlobUploadResp.VersionID()
@@ -139,7 +139,7 @@ func (s *aztestsSuite) TestUploadBlockBlobWithSpecialCharactersInTags(c *chk.C) 
 		"tag2":     "+-./:=_",
 		"+-./:=_1": "+-./:=_",
 	}
-	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap)
+	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.StatusCode(), chk.Equals, 201)
 
@@ -169,7 +169,7 @@ func (s *aztestsSuite) TestStageBlockWithTags(c *chk.C) {
 
 	for index, d := range data {
 		base64BlockIDs[index] = blockIDIntToBase64(index)
-		resp, err := blobURL.StageBlock(ctx, base64BlockIDs[index], strings.NewReader(d), LeaseAccessConditions{}, nil)
+		resp, err := blobURL.StageBlock(ctx, base64BlockIDs[index], strings.NewReader(d), LeaseAccessConditions{}, nil, ClientProvidedKeyOptions{})
 		if err != nil {
 			c.Fail()
 		}
@@ -182,12 +182,12 @@ func (s *aztestsSuite) TestStageBlockWithTags(c *chk.C) {
 		"blob":  "sdk",
 		"sdk":   "go",
 	}
-	commitResp, err := blobURL.CommitBlockList(ctx, base64BlockIDs, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap)
+	commitResp, err := blobURL.CommitBlockList(ctx, base64BlockIDs, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(commitResp.VersionID(), chk.NotNil)
 	versionId := commitResp.VersionID()
 
-	contentResp, err := blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false)
+	contentResp, err := blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	contentData, err := ioutil.ReadAll(contentResp.Body(RetryReaderOptions{}))
 	c.Assert(contentData, chk.DeepEquals, []uint8(strings.Join(data, "")))
@@ -230,7 +230,7 @@ func (s *aztestsSuite) TestStageBlockFromURLWithTags(c *chk.C) {
 		"Javascript": "Android",
 	}
 
-	uploadSrcResp, err := srcBlob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap)
+	uploadSrcResp, err := srcBlob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadSrcResp.Response().StatusCode, chk.Equals, 201)
 
@@ -251,7 +251,7 @@ func (s *aztestsSuite) TestStageBlockFromURLWithTags(c *chk.C) {
 	srcBlobURLWithSAS := srcBlobParts.URL()
 
 	blockID1, blockID2 := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%6d", 0))), base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%6d", 1)))
-	stageResp1, err := destBlob.StageBlockFromURL(ctx, blockID1, srcBlobURLWithSAS, 0, 4*1024*1024, LeaseAccessConditions{}, ModifiedAccessConditions{})
+	stageResp1, err := destBlob.StageBlockFromURL(ctx, blockID1, srcBlobURLWithSAS, 0, 4*1024*1024, LeaseAccessConditions{}, ModifiedAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(stageResp1.Response().StatusCode, chk.Equals, 201)
 	c.Assert(stageResp1.ContentMD5(), chk.Not(chk.Equals), "")
@@ -259,7 +259,7 @@ func (s *aztestsSuite) TestStageBlockFromURLWithTags(c *chk.C) {
 	c.Assert(stageResp1.Version(), chk.Not(chk.Equals), "")
 	c.Assert(stageResp1.Date().IsZero(), chk.Equals, false)
 
-	stageResp2, err := destBlob.StageBlockFromURL(ctx, blockID2, srcBlobURLWithSAS, 4*1024*1024, CountToEnd, LeaseAccessConditions{}, ModifiedAccessConditions{})
+	stageResp2, err := destBlob.StageBlockFromURL(ctx, blockID2, srcBlobURLWithSAS, 4*1024*1024, CountToEnd, LeaseAccessConditions{}, ModifiedAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(stageResp2.Response().StatusCode, chk.Equals, 201)
 	c.Assert(stageResp2.ContentMD5(), chk.Not(chk.Equals), "")
@@ -273,12 +273,12 @@ func (s *aztestsSuite) TestStageBlockFromURLWithTags(c *chk.C) {
 	c.Assert(blockList.CommittedBlocks, chk.HasLen, 0)
 	c.Assert(blockList.UncommittedBlocks, chk.HasLen, 2)
 
-	listResp, err := destBlob.CommitBlockList(ctx, []string{blockID1, blockID2}, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap)
+	listResp, err := destBlob.CommitBlockList(ctx, []string{blockID1, blockID2}, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(listResp.Response().StatusCode, chk.Equals, 201)
 	//versionId := listResp.VersionID()
 
-	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false)
+	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
 	c.Assert(err, chk.IsNil)
@@ -313,7 +313,7 @@ func (s *aztestsSuite) TestCopyBlockBlobFromURLWithTags(c *chk.C) {
 		"Javascript": "Android",
 	}
 
-	uploadSrcResp, err := srcBlob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap)
+	uploadSrcResp, err := srcBlob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadSrcResp.Response().StatusCode, chk.Equals, 201)
 
@@ -344,7 +344,7 @@ func (s *aztestsSuite) TestCopyBlockBlobFromURLWithTags(c *chk.C) {
 	c.Assert(resp.ContentMD5(), chk.DeepEquals, sourceDataMD5Value[:])
 	c.Assert(string(resp.CopyStatus()), chk.DeepEquals, "success")
 
-	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false)
+	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
 	c.Assert(err, chk.IsNil)
@@ -372,15 +372,15 @@ func (s *aztestsSuite) TestGetPropertiesReturnsTagsCount(c *chk.C) {
 		"blob":  "sdk",
 		"sdk":   "go",
 	}
-	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap)
+	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.StatusCode(), chk.Equals, 201)
 
-	getPropertiesResponse, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	getPropertiesResponse, err := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(getPropertiesResponse.TagCount(), chk.Equals, int64(3))
 
-	downloadResp, err := blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false)
+	downloadResp, err := blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(downloadResp, chk.NotNil)
 	c.Assert(downloadResp.r.rawResponse.Header.Get("x-ms-tag-count"), chk.Equals, "3")
@@ -399,11 +399,11 @@ func (s *aztestsSuite) TestSetBlobTagForSnapshot(c *chk.C) {
 	_, err := blobURL.SetTags(ctx, nil, nil, nil, nil, nil, nil, blobTagsMap)
 	c.Assert(err, chk.IsNil)
 
-	resp, err := blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{})
+	resp, err := blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	snapshotURL := blobURL.WithSnapshot(resp.Snapshot())
-	resp2, err := snapshotURL.GetProperties(ctx, BlobAccessConditions{})
+	resp2, err := snapshotURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp2.TagCount(), chk.Equals, int64(3))
 }
@@ -419,7 +419,7 @@ func (s *aztestsSuite) TestCreatePageBlobWithTags(c *chk.C) {
 		"sdk":   "go",
 	}
 	blob, _ := createNewPageBlob(c, container)
-	putResp, err := blob.UploadPages(ctx, 0, getReaderToRandomBytes(1024), PageBlobAccessConditions{}, nil)
+	putResp, err := blob.UploadPages(ctx, 0, getReaderToRandomBytes(1024), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(putResp.Response().StatusCode, chk.Equals, 201)
 	c.Assert(putResp.LastModified().IsZero(), chk.Equals, false)
@@ -431,7 +431,7 @@ func (s *aztestsSuite) TestCreatePageBlobWithTags(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 	c.Assert(setTagResp.StatusCode(), chk.Equals, 204)
 
-	gpResp, err := blob.GetProperties(ctx, BlobAccessConditions{})
+	gpResp, err := blob.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(gpResp, chk.NotNil)
 	c.Assert(gpResp.rawResponse.Header.Get("x-ms-tag-count"), chk.Equals, "3")
@@ -445,7 +445,7 @@ func (s *aztestsSuite) TestCreatePageBlobWithTags(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 	c.Assert(setTagResp.StatusCode(), chk.Equals, 204)
 
-	gpResp, err = blob.GetProperties(ctx, BlobAccessConditions{})
+	gpResp, err = blob.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(gpResp, chk.NotNil)
 	c.Assert(gpResp.rawResponse.Header.Get("x-ms-tag-count"), chk.Equals, "2")
@@ -462,11 +462,11 @@ func (s *aztestsSuite) TestSetTagOnPageBlob(c *chk.C) {
 		"blob":  "sdk",
 		"sdk":   "go",
 	}
-	resp, err := blob.Create(ctx, PageBlobPageBytes*10, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, blobTagsMap)
+	resp, err := blob.Create(ctx, PageBlobPageBytes*10, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, blobTagsMap, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.StatusCode(), chk.Equals, 201)
 
-	gpResp, err := blob.GetProperties(ctx, BlobAccessConditions{})
+	gpResp, err := blob.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(gpResp, chk.NotNil)
 	c.Assert(gpResp.rawResponse.Header.Get("x-ms-tag-count"), chk.Equals, "3")
@@ -480,7 +480,7 @@ func (s *aztestsSuite) TestSetTagOnPageBlob(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 	c.Assert(setTagResp.StatusCode(), chk.Equals, 204)
 
-	gpResp, err = blob.GetProperties(ctx, BlobAccessConditions{})
+	gpResp, err = blob.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(gpResp, chk.NotNil)
 	c.Assert(gpResp.rawResponse.Header.Get("x-ms-tag-count"), chk.Equals, "2")
@@ -492,11 +492,11 @@ func (s *aztestsSuite) TestCreateAppendBlobWithTags(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewAppendBlob(c, containerURL)
 
-	blobProp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
-	createResp, err := blobURL.Create(ctx, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: blobProp.ETag()}}, nil)
+	blobProp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
+	createResp, err := blobURL.Create(ctx, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: blobProp.ETag()}}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(createResp.VersionID(), chk.NotNil)
-	blobProp, _ = blobURL.GetProperties(ctx, BlobAccessConditions{})
+	blobProp, _ = blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(createResp.VersionID(), chk.Equals, blobProp.VersionID())
 	c.Assert(createResp.LastModified(), chk.DeepEquals, blobProp.LastModified())
 	c.Assert(createResp.ETag(), chk.Equals, blobProp.ETag())
@@ -546,21 +546,21 @@ func (s *aztestsSuite) TestFindBlobsByTags(c *chk.C) {
 		"tag3": "thirdtag",
 	}
 	blobURL11, _ := getBlockBlobURL(c, containerURL1)
-	_, err := blobURL11.Upload(ctx, bytes.NewReader([]byte("random data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap1)
+	_, err := blobURL11.Upload(ctx, bytes.NewReader([]byte("random data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap1, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	blobURL12, _ := getBlockBlobURL(c, containerURL1)
-	_, err = blobURL12.Upload(ctx, bytes.NewReader([]byte("another random data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap2)
+	_, err = blobURL12.Upload(ctx, bytes.NewReader([]byte("another random data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap2, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	blobURL21, _ := getBlockBlobURL(c, containerURL2)
-	_, err = blobURL21.Upload(ctx, bytes.NewReader([]byte("random data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	_, err = blobURL21.Upload(ctx, bytes.NewReader([]byte("random data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	blobURL22, _ := getBlockBlobURL(c, containerURL2)
-	_, err = blobURL22.Upload(ctx, bytes.NewReader([]byte("another random data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap2)
+	_, err = blobURL22.Upload(ctx, bytes.NewReader([]byte("another random data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, blobTagsMap2, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	blobURL31, _ := getBlockBlobURL(c, containerURL3)
-	_, err = blobURL31.Upload(ctx, bytes.NewReader([]byte("random data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	_, err = blobURL31.Upload(ctx, bytes.NewReader([]byte("random data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	where := "\"tag4\"='fourthtag'"
@@ -612,7 +612,7 @@ func (s *aztestsSuite) TestFilterBlobsUsingAccountSAS(c *chk.C) {
 	}
 
 	blobURL := containerURL.NewBlockBlobURL("temp")
-	_, err = blobURL.Upload(ctx, bytes.NewReader([]byte("random data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	_, err = blobURL.Upload(ctx, bytes.NewReader([]byte("random data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	if err != nil {
 		c.Fail()
 	}

--- a/azblob/zt_blob_versioning_test.go
+++ b/azblob/zt_blob_versioning_test.go
@@ -21,11 +21,11 @@ func (s *aztestsSuite) TestGetBlobPropertiesUsingVID(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewAppendBlob(c, containerURL)
 
-	blobProp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
-	createResp, err := blobURL.Create(ctx, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: blobProp.ETag()}}, nil)
+	blobProp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
+	createResp, err := blobURL.Create(ctx, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: blobProp.ETag()}}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(createResp.VersionID(), chk.NotNil)
-	blobProp, _ = blobURL.GetProperties(ctx, BlobAccessConditions{})
+	blobProp, _ = blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(createResp.VersionID(), chk.Equals, blobProp.VersionID())
 	c.Assert(createResp.LastModified(), chk.DeepEquals, blobProp.LastModified())
 	c.Assert(createResp.ETag(), chk.Equals, blobProp.ETag())
@@ -38,7 +38,7 @@ func (s *aztestsSuite) TestSetBlobMetadataReturnsVID(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, blobName := createNewBlockBlob(c, containerURL)
 	metadata := Metadata{"test_key_1": "test_value_1", "test_key_2": "2019"}
-	resp, err := blobURL.SetMetadata(ctx, metadata, BlobAccessConditions{})
+	resp, err := blobURL.SetMetadata(ctx, metadata, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.VersionID(), chk.NotNil)
 
@@ -58,11 +58,11 @@ func (s *aztestsSuite) TestCreateAndDownloadBlobSpecialCharactersWithVID(c *chk.
 	for i := 0; i < len(data); i++ {
 		blobName := "abc" + string(data[i])
 		blobURL := containerURL.NewBlockBlobURL(blobName)
-		resp, err := blobURL.Upload(ctx, strings.NewReader(string(data[i])), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil)
+		resp, err := blobURL.Upload(ctx, strings.NewReader(string(data[i])), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 		c.Assert(err, chk.IsNil)
 		c.Assert(resp.VersionID(), chk.NotNil)
 
-		dResp, err := blobURL.WithVersionID(resp.VersionID()).Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false)
+		dResp, err := blobURL.WithVersionID(resp.VersionID()).Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 		c.Assert(err, chk.IsNil)
 		d1, err := ioutil.ReadAll(dResp.Body(RetryReaderOptions{}))
 		c.Assert(dResp.Version(), chk.Not(chk.Equals), "")
@@ -79,12 +79,12 @@ func (s *aztestsSuite) TestDeleteSpecificBlobVersion(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getBlockBlobURL(c, containerURL)
 
-	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.VersionID(), chk.NotNil)
 	versionID1 := blockBlobUploadResp.VersionID()
 
-	blockBlobUploadResp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	blockBlobUploadResp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.VersionID(), chk.NotNil)
 
@@ -115,12 +115,12 @@ func (s *aztestsSuite) TestDeleteSpecificBlobVersionWithBlobSAS(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, blobName := getBlockBlobURL(c, containerURL)
 
-	resp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	resp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	versionId := resp.VersionID()
 	c.Assert(versionId, chk.NotNil)
 
-	resp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	resp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.VersionID(), chk.NotNil)
 
@@ -154,12 +154,12 @@ func (s *aztestsSuite) TestDownloadSpecificBlobVersion(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getBlockBlobURL(c, containerURL)
 
-	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp, chk.NotNil)
 	versionId1 := blockBlobUploadResp.VersionID()
 
-	blockBlobUploadResp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	blockBlobUploadResp, err = blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp, chk.NotNil)
 	versionId2 := blockBlobUploadResp.VersionID()
@@ -167,14 +167,14 @@ func (s *aztestsSuite) TestDownloadSpecificBlobVersion(c *chk.C) {
 
 	// Download previous version of snapshot.
 	blobURL = blobURL.WithVersionID(versionId1)
-	blockBlobDeleteResp, err := blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false)
+	blockBlobDeleteResp, err := blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	data, err := ioutil.ReadAll(blockBlobDeleteResp.Response().Body)
 	c.Assert(string(data), chk.Equals, "data")
 
 	// Download current version of snapshot.
 	blobURL = blobURL.WithVersionID(versionId2)
-	blockBlobDeleteResp, err = blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false)
+	blockBlobDeleteResp, err = blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	data, err = ioutil.ReadAll(blockBlobDeleteResp.Response().Body)
 	c.Assert(string(data), chk.Equals, "updated_data")
@@ -185,11 +185,11 @@ func (s *aztestsSuite) TestCreateBlobSnapshotReturnsVID(c *chk.C) {
 	containerURL, _ := createNewContainer(c, bsu)
 	defer delContainer(c, containerURL)
 	blobURL := containerURL.NewBlockBlobURL(generateBlobName())
-	uploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil)
+	uploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("updated_data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadResp.VersionID(), chk.NotNil)
 
-	csResp, err := blobURL.CreateSnapshot(ctx, Metadata{}, BlobAccessConditions{})
+	csResp, err := blobURL.CreateSnapshot(ctx, Metadata{}, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(csResp.VersionID(), chk.NotNil)
 	lbResp, err := containerURL.ListBlobsFlatSegment(ctx, Marker{}, ListBlobsSegmentOptions{
@@ -229,7 +229,7 @@ func (s *aztestsSuite) TestCopyBlobFromURLWithSASReturnsVID(c *chk.C) {
 	srcBlob := container.NewBlockBlobURL(generateBlobName())
 	destBlob := container.NewBlockBlobURL(generateBlobName())
 
-	uploadSrcResp, err := srcBlob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil)
+	uploadSrcResp, err := srcBlob.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadSrcResp.Response().StatusCode, chk.Equals, 201)
 	c.Assert(uploadSrcResp.Response().Header.Get("x-ms-version-id"), chk.NotNil)
@@ -257,7 +257,7 @@ func (s *aztestsSuite) TestCopyBlobFromURLWithSASReturnsVID(c *chk.C) {
 	c.Assert(string(resp.CopyStatus()), chk.DeepEquals, "success")
 	c.Assert(resp.VersionID(), chk.NotNil)
 
-	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false)
+	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
 	c.Assert(err, chk.IsNil)
@@ -287,13 +287,13 @@ func (s *aztestsSuite) TestCreateBlockBlobReturnsVID(c *chk.C) {
 	blobURL := containerURL.NewBlockBlobURL(generateBlobName())
 
 	// Prepare source blob for copy.
-	uploadResp, err := blobURL.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil)
+	uploadResp, err := blobURL.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadResp.Response().StatusCode, chk.Equals, 201)
 	c.Assert(uploadResp.rawResponse.Header.Get("x-ms-version"), chk.Equals, ServiceVersion)
 	c.Assert(uploadResp.Response().Header.Get("x-ms-version-id"), chk.NotNil)
 
-	csResp, err := blobURL.CreateSnapshot(ctx, Metadata{}, BlobAccessConditions{})
+	csResp, err := blobURL.CreateSnapshot(ctx, Metadata{}, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(csResp.Response().StatusCode, chk.Equals, 201)
 	c.Assert(csResp.Response().Header.Get("x-ms-version-id"), chk.NotNil)
@@ -337,7 +337,7 @@ func (s *aztestsSuite) TestPutBlockListReturnsVID(c *chk.C) {
 
 	for index, d := range data {
 		base64BlockIDs[index] = blockIDIntToBase64(index)
-		resp, err := blobURL.StageBlock(ctx, base64BlockIDs[index], strings.NewReader(d), LeaseAccessConditions{}, nil)
+		resp, err := blobURL.StageBlock(ctx, base64BlockIDs[index], strings.NewReader(d), LeaseAccessConditions{}, nil, ClientProvidedKeyOptions{})
 		if err != nil {
 			c.Fail()
 		}
@@ -345,11 +345,11 @@ func (s *aztestsSuite) TestPutBlockListReturnsVID(c *chk.C) {
 		c.Assert(resp.Version(), chk.Not(chk.Equals), "")
 	}
 
-	commitResp, err := blobURL.CommitBlockList(ctx, base64BlockIDs, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil)
+	commitResp, err := blobURL.CommitBlockList(ctx, base64BlockIDs, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(commitResp.VersionID(), chk.NotNil)
 
-	contentResp, err := blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false)
+	contentResp, err := blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	contentData, err := ioutil.ReadAll(contentResp.Body(RetryReaderOptions{}))
 	c.Assert(contentData, chk.DeepEquals, []uint8(strings.Join(data, "")))
@@ -365,7 +365,7 @@ func (s *aztestsSuite) TestCreatePageBlobReturnsVID(c *chk.C) {
 	defer delContainer(c, container)
 
 	blob, _ := createNewPageBlob(c, container)
-	putResp, err := blob.UploadPages(context.Background(), 0, getReaderToRandomBytes(1024), PageBlobAccessConditions{}, nil)
+	putResp, err := blob.UploadPages(context.Background(), 0, getReaderToRandomBytes(1024), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(putResp.Response().StatusCode, chk.Equals, 201)
 	c.Assert(putResp.LastModified().IsZero(), chk.Equals, false)
@@ -373,7 +373,7 @@ func (s *aztestsSuite) TestCreatePageBlobReturnsVID(c *chk.C) {
 	c.Assert(putResp.Version(), chk.Not(chk.Equals), "")
 	c.Assert(putResp.rawResponse.Header.Get("x-ms-version-id"), chk.NotNil)
 
-	gpResp, err := blob.GetProperties(ctx, BlobAccessConditions{})
+	gpResp, err := blob.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(gpResp, chk.NotNil)
 }

--- a/azblob/zt_client_provided_key_test.go
+++ b/azblob/zt_client_provided_key_test.go
@@ -42,10 +42,11 @@ func blockIDIntToBase64(blockID int) string {
 	binary.LittleEndian.PutUint32(binaryBlockID, uint32(blockID))
 	return blockIDBinaryToBase64(binaryBlockID)
 }
-func blockIDBase64ToInt(blockID string) int {
-	blockIDBase64ToBinary(blockID)
-	return int(binary.LittleEndian.Uint32(blockIDBase64ToBinary(blockID)))
-}
+
+//func blockIDBase64ToInt(blockID string) int {
+//	blockIDBase64ToBinary(blockID)
+//	return int(binary.LittleEndian.Uint32(blockIDBase64ToBinary(blockID)))
+//}
 
 func (s *aztestsSuite) TestPutBlockAndPutBlockListWithCPK(c *chk.C) {
 	bsu := getBSU()
@@ -78,7 +79,7 @@ func (s *aztestsSuite) TestPutBlockAndPutBlockListWithCPK(c *chk.C) {
 	getResp, err := blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false, testCPK)
 	c.Assert(err, chk.IsNil)
 	b := bytes.Buffer{}
-	reader := getResp.Body(RetryReaderOptions{})
+	reader := getResp.Body(RetryReaderOptions{ClientProvidedKeyOptions: testCPK})
 	b.ReadFrom(reader)
 	reader.Close() // The client must close the response body when finished with it
 	c.Assert(b.String(), chk.Equals, "AAA BBB CCC ")
@@ -130,7 +131,7 @@ func (s *aztestsSuite) TestPutBlockAndPutBlockListWithCPKByScope(c *chk.C) {
 	getResp, err = blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false, testCPK1)
 	c.Assert(err, chk.IsNil)
 	b = bytes.Buffer{}
-	reader = getResp.Body(RetryReaderOptions{})
+	reader = getResp.Body(RetryReaderOptions{ClientProvidedKeyOptions: testCPK1})
 	b.ReadFrom(reader)
 	reader.Close() // The client must close the response body when finished with it
 	c.Assert(b.String(), chk.Equals, "AAA BBB CCC ")
@@ -215,7 +216,7 @@ func (s *aztestsSuite) TestPutBlockFromURLAndCommitWithCPK(c *chk.C) {
 	// Download blob to do data integrity check.
 	downloadResp, err = destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
 	c.Assert(err, chk.IsNil)
-	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{ClientProvidedKeyOptions: testCPK}))
 	c.Assert(err, chk.IsNil)
 	c.Assert(destData, chk.DeepEquals, srcData)
 }
@@ -402,7 +403,7 @@ func (s *aztestsSuite) TestAppendBlockWithCPKByScope(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 	c.Assert(downloadResp.IsServerEncrypted(), chk.Equals, "true")
 
-	data, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	data, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{ClientProvidedKeyOptions: testCPK1}))
 	c.Assert(err, chk.IsNil)
 	c.Assert(string(data), chk.DeepEquals, "AAA BBB CCC ")
 	c.Assert(downloadResp.r.rawResponse.Header.Get("x-ms-encryption-scope"), chk.Equals, *(testCPK1.EncryptionScope))
@@ -465,7 +466,7 @@ func (s *aztestsSuite) TestAppendBlockFromURLWithCPK(c *chk.C) {
 	// Download blob to do data integrity check.
 	downloadResp, err = destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
 	c.Assert(err, chk.IsNil)
-	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{ClientProvidedKeyOptions: testCPK}))
 	c.Assert(err, chk.IsNil)
 	c.Assert(destData, chk.DeepEquals, srcData)
 }
@@ -490,7 +491,7 @@ func (s *aztestsSuite) TestPageBlockWithCPK(c *chk.C) {
 	// Download blob to do data integrity check.
 	downloadResp, err = blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
 	c.Assert(err, chk.IsNil)
-	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{ClientProvidedKeyOptions: testCPK}))
 	c.Assert(err, chk.IsNil)
 	c.Assert(destData, chk.DeepEquals, srcData)
 }
@@ -512,7 +513,7 @@ func (s *aztestsSuite) TestPageBlockWithCPKByScope(c *chk.C) {
 	// Download blob to do data integrity check.
 	downloadResp, err := blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK1)
 	c.Assert(err, chk.IsNil)
-	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{ClientProvidedKeyOptions: testCPK1}))
 	c.Assert(err, chk.IsNil)
 	c.Assert(destData, chk.DeepEquals, srcData)
 	c.Assert(downloadResp.r.rawResponse.Header.Get("x-ms-encryption-scope"), chk.Equals, *(testCPK1.EncryptionScope))
@@ -562,7 +563,7 @@ func (s *aztestsSuite) TestPageBlockFromURLWithCPK(c *chk.C) {
 	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
 	c.Assert(err, chk.IsNil)
 	c.Assert(downloadResp.r.EncryptionKeySha256(), chk.Equals, *(testCPK.EncryptionKeySha256))
-	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{ClientProvidedKeyOptions: testCPK}))
 	c.Assert(err, chk.IsNil)
 	c.Assert(destData, chk.DeepEquals, srcData)
 }
@@ -611,7 +612,7 @@ func (s *aztestsSuite) TestUploadPagesFromURLWithMD5WithCPK(c *chk.C) {
 	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
 	c.Assert(err, chk.IsNil)
 	c.Assert(downloadResp.r.EncryptionKeySha256(), chk.Equals, *(testCPK.EncryptionKeySha256))
-	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{ClientProvidedKeyOptions: testCPK}))
 	c.Assert(err, chk.IsNil)
 	c.Assert(destData, chk.DeepEquals, srcData)
 

--- a/azblob/zt_client_provided_key_test.go
+++ b/azblob/zt_client_provided_key_test.go
@@ -1,0 +1,737 @@
+package azblob
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/binary"
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"time"
+
+	chk "gopkg.in/check.v1" // go get gopkg.in/check.v1
+)
+
+/*
+Azure Storage supports following operations support of sending customer-provided encryption keys on a request:
+Put Blob, Put Block List, Put Block, Put Block from URL, Put Page, Put Page from URL, Append Block,
+Set Blob Properties, Set Blob Metadata, Get Blob, Get Blob Properties, Get Blob Metadata, Snapshot Blob.
+*/
+var testEncryptedKey = "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc="
+var testEncryptedHash = "3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE="
+var testEncryptedScope = ""
+var testCPK = NewClientProvidedKeyOptions(&testEncryptedKey, &testEncryptedHash, &testEncryptedScope)
+
+var testEncryptedScope1 = "blobgokeytestscope"
+var testCPK1 = ClientProvidedKeyOptions{EncryptionScope: &testEncryptedScope1}
+
+func blockIDBinaryToBase64(blockID []byte) string {
+	return base64.StdEncoding.EncodeToString(blockID)
+}
+
+func blockIDBase64ToBinary(blockID string) []byte {
+	binary, _ := base64.StdEncoding.DecodeString(blockID)
+	return binary
+}
+
+// blockIDIntToBase64 functions convert an int block ID to a base-64 string and vice versa
+func blockIDIntToBase64(blockID int) string {
+	binaryBlockID := (&[4]byte{})[:] // All block IDs are 4 bytes long
+	binary.LittleEndian.PutUint32(binaryBlockID, uint32(blockID))
+	return blockIDBinaryToBase64(binaryBlockID)
+}
+func blockIDBase64ToInt(blockID string) int {
+	blockIDBase64ToBinary(blockID)
+	return int(binary.LittleEndian.Uint32(blockIDBase64ToBinary(blockID)))
+}
+
+func (s *aztestsSuite) TestPutBlockAndPutBlockListWithCPK(c *chk.C) {
+	bsu := getBSU()
+	container, _ := createNewContainer(c, bsu)
+	defer delContainer(c, container)
+
+	blobURL := container.NewBlockBlobURL(generateBlobName())
+
+	words := []string{"AAA ", "BBB ", "CCC "}
+	base64BlockIDs := make([]string, len(words))
+	for index, word := range words {
+		base64BlockIDs[index] = blockIDIntToBase64(index)
+		_, err := blobURL.StageBlock(ctx, base64BlockIDs[index], strings.NewReader(word), LeaseAccessConditions{}, nil, testCPK)
+		c.Assert(err, chk.IsNil)
+	}
+
+	resp, err := blobURL.CommitBlockList(ctx, base64BlockIDs, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, testCPK)
+	c.Assert(err, chk.IsNil)
+
+	c.Assert(resp.ETag(), chk.NotNil)
+	c.Assert(resp.LastModified(), chk.NotNil)
+	c.Assert(resp.IsServerEncrypted(), chk.Equals, "true")
+	c.Assert(resp.EncryptionKeySha256(), chk.DeepEquals, *(testCPK.EncryptionKeySha256))
+
+	// Get blob content without encryption key should fail the request.
+	_, err = blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+
+	// Download blob to do data integrity check.
+	getResp, err := blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false, testCPK)
+	c.Assert(err, chk.IsNil)
+	b := bytes.Buffer{}
+	reader := getResp.Body(RetryReaderOptions{})
+	b.ReadFrom(reader)
+	reader.Close() // The client must close the response body when finished with it
+	c.Assert(b.String(), chk.Equals, "AAA BBB CCC ")
+	c.Assert(getResp.ETag(), chk.Equals, resp.ETag())
+	c.Assert(getResp.LastModified(), chk.DeepEquals, resp.LastModified())
+}
+
+func (s *aztestsSuite) TestPutBlockAndPutBlockListWithCPKByScope(c *chk.C) {
+	bsu := getBSU()
+	container, _ := createNewContainer(c, bsu)
+	defer delContainer(c, container)
+
+	blobURL := container.NewBlockBlobURL(generateBlobName())
+
+	words := []string{"AAA ", "BBB ", "CCC "}
+	base64BlockIDs := make([]string, len(words))
+	for index, word := range words {
+		base64BlockIDs[index] = blockIDIntToBase64(index)
+		_, err := blobURL.StageBlock(ctx, base64BlockIDs[index], strings.NewReader(word), LeaseAccessConditions{}, nil, testCPK1)
+		c.Assert(err, chk.IsNil)
+	}
+
+	resp, err := blobURL.CommitBlockList(ctx, base64BlockIDs, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, testCPK1)
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.ETag(), chk.NotNil)
+	c.Assert(resp.LastModified(), chk.NotNil)
+	c.Assert(resp.IsServerEncrypted(), chk.Equals, "true")
+	c.Assert(resp.EncryptionScope(), chk.Equals, *(testCPK1.EncryptionScope))
+
+	getResp, err := blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false, testCPK)
+	c.Assert(err, chk.NotNil)
+	serr := err.(StorageError)
+	c.Assert(serr.Response().StatusCode, chk.Equals, 409)
+	c.Assert(serr.ServiceCode(), chk.Equals, ServiceCodeFeatureEncryptionMismatch)
+
+	getResp, err = blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.IsNil)
+	b := bytes.Buffer{}
+	reader := getResp.Body(RetryReaderOptions{})
+	b.ReadFrom(reader)
+	reader.Close() // The client must close the response body when finished with it
+	c.Assert(b.String(), chk.Equals, "AAA BBB CCC ")
+	c.Assert(getResp.ETag(), chk.Equals, resp.ETag())
+	c.Assert(getResp.LastModified(), chk.DeepEquals, resp.LastModified())
+	c.Assert(getResp.LastModified(), chk.DeepEquals, resp.LastModified())
+	c.Assert(getResp.r.rawResponse.Header.Get("x-ms-encryption-scope"), chk.Equals, *(testCPK1.EncryptionScope))
+
+	// Download blob to do data integrity check.
+	getResp, err = blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false, testCPK1)
+	c.Assert(err, chk.IsNil)
+	b = bytes.Buffer{}
+	reader = getResp.Body(RetryReaderOptions{})
+	b.ReadFrom(reader)
+	reader.Close() // The client must close the response body when finished with it
+	c.Assert(b.String(), chk.Equals, "AAA BBB CCC ")
+	c.Assert(getResp.ETag(), chk.Equals, resp.ETag())
+	c.Assert(getResp.LastModified(), chk.DeepEquals, resp.LastModified())
+	c.Assert(getResp.r.rawResponse.Header.Get("x-ms-encryption-scope"), chk.Equals, *(testCPK1.EncryptionScope))
+}
+
+func (s *aztestsSuite) TestPutBlockFromURLAndCommitWithCPK(c *chk.C) {
+	bsu := getBSU()
+	credential, err := getGenericCredential("")
+	if err != nil {
+		c.Fatal("Invalid credential")
+	}
+	container, _ := createNewContainer(c, bsu)
+	defer delContainer(c, container)
+
+	testSize := 2 * 1024 // 2KB
+	r, srcData := getRandomDataAndReader(testSize)
+	ctx := context.Background()
+	blobURL := container.NewBlockBlobURL(generateBlobName())
+
+	uploadSrcResp, err := blobURL.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(uploadSrcResp.Response().StatusCode, chk.Equals, 201)
+
+	srcBlobParts := NewBlobURLParts(blobURL.URL())
+
+	srcBlobParts.SAS, err = BlobSASSignatureValues{
+		Protocol:      SASProtocolHTTPS,
+		ExpiryTime:    time.Now().UTC().Add(1 * time.Hour),
+		ContainerName: srcBlobParts.ContainerName,
+		BlobName:      srcBlobParts.BlobName,
+		Permissions:   BlobSASPermissions{Read: true}.String(),
+	}.NewSASQueryParameters(credential)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	srcBlobURLWithSAS := srcBlobParts.URL()
+	destBlob := container.NewBlockBlobURL(generateBlobName())
+	blockID1, blockID2 := blockIDIntToBase64(0), blockIDIntToBase64(1)
+	stageResp1, err := destBlob.StageBlockFromURL(ctx, blockID1, srcBlobURLWithSAS, 0, 1*1024, LeaseAccessConditions{}, ModifiedAccessConditions{}, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(stageResp1.Response().StatusCode, chk.Equals, 201)
+	c.Assert(stageResp1.ContentMD5(), chk.Not(chk.Equals), "")
+	c.Assert(stageResp1.RequestID(), chk.Not(chk.Equals), "")
+	c.Assert(stageResp1.Version(), chk.Not(chk.Equals), "")
+	c.Assert(stageResp1.Date().IsZero(), chk.Equals, false)
+	c.Assert(stageResp1.IsServerEncrypted(), chk.Equals, "true")
+
+	stageResp2, err := destBlob.StageBlockFromURL(ctx, blockID2, srcBlobURLWithSAS, 1*1024, CountToEnd, LeaseAccessConditions{}, ModifiedAccessConditions{}, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(stageResp2.Response().StatusCode, chk.Equals, 201)
+	c.Assert(stageResp2.ContentMD5(), chk.Not(chk.Equals), "")
+	c.Assert(stageResp2.RequestID(), chk.Not(chk.Equals), "")
+	c.Assert(stageResp2.Version(), chk.Not(chk.Equals), "")
+	c.Assert(stageResp2.Date().IsZero(), chk.Equals, false)
+	c.Assert(stageResp2.IsServerEncrypted(), chk.Equals, "true")
+
+	blockList, err := destBlob.GetBlockList(ctx, BlockListAll, LeaseAccessConditions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(blockList.Response().StatusCode, chk.Equals, 200)
+	c.Assert(blockList.UncommittedBlocks, chk.HasLen, 2)
+	c.Assert(blockList.CommittedBlocks, chk.HasLen, 0)
+
+	listResp, err := destBlob.CommitBlockList(ctx, []string{blockID1, blockID2}, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultAccessTier, nil, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(listResp.Response().StatusCode, chk.Equals, 201)
+	c.Assert(listResp.IsServerEncrypted(), chk.Equals, "true")
+
+	blockList, err = destBlob.GetBlockList(ctx, BlockListAll, LeaseAccessConditions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(blockList.Response().StatusCode, chk.Equals, 200)
+	c.Assert(blockList.UncommittedBlocks, chk.HasLen, 0)
+	c.Assert(blockList.CommittedBlocks, chk.HasLen, 2)
+
+	// Get blob content without encryption key should fail the request.
+	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+
+	// Download blob to do data integrity check.
+	downloadResp, err = destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
+	c.Assert(err, chk.IsNil)
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	c.Assert(err, chk.IsNil)
+	c.Assert(destData, chk.DeepEquals, srcData)
+}
+
+func (s *aztestsSuite) TestPutBlockFromURLAndCommitWithCPKWithScope(c *chk.C) {
+	bsu := getBSU()
+	credential, err := getGenericCredential("")
+	if err != nil {
+		c.Fatal("Invalid credential")
+	}
+	container, _ := createNewContainer(c, bsu)
+	defer delContainer(c, container)
+
+	testSize := 2 * 1024 // 2KB
+	r, srcData := getRandomDataAndReader(testSize)
+	ctx := context.Background()
+	blobURL := container.NewBlockBlobURL(generateBlobName())
+
+	uploadSrcResp, err := blobURL.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(uploadSrcResp.Response().StatusCode, chk.Equals, 201)
+
+	srcBlobParts := NewBlobURLParts(blobURL.URL())
+
+	srcBlobParts.SAS, err = BlobSASSignatureValues{
+		Protocol:      SASProtocolHTTPS,
+		ExpiryTime:    time.Now().UTC().Add(1 * time.Hour),
+		ContainerName: srcBlobParts.ContainerName,
+		BlobName:      srcBlobParts.BlobName,
+		Permissions:   BlobSASPermissions{Read: true}.String(),
+	}.NewSASQueryParameters(credential)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	srcBlobURLWithSAS := srcBlobParts.URL()
+	destBlob := container.NewBlockBlobURL(generateBlobName())
+	blockID1, blockID2 := blockIDIntToBase64(0), blockIDIntToBase64(1)
+	stageResp1, err := destBlob.StageBlockFromURL(ctx, blockID1, srcBlobURLWithSAS, 0, 1*1024, LeaseAccessConditions{}, ModifiedAccessConditions{}, testCPK1)
+	c.Assert(err, chk.IsNil)
+	c.Assert(stageResp1.Response().StatusCode, chk.Equals, 201)
+	c.Assert(stageResp1.ContentMD5(), chk.Not(chk.Equals), "")
+	c.Assert(stageResp1.RequestID(), chk.Not(chk.Equals), "")
+	c.Assert(stageResp1.Version(), chk.Not(chk.Equals), "")
+	c.Assert(stageResp1.Date().IsZero(), chk.Equals, false)
+	c.Assert(stageResp1.IsServerEncrypted(), chk.Equals, "true")
+
+	stageResp2, err := destBlob.StageBlockFromURL(ctx, blockID2, srcBlobURLWithSAS, 1*1024, CountToEnd, LeaseAccessConditions{}, ModifiedAccessConditions{}, testCPK1)
+	c.Assert(err, chk.IsNil)
+	c.Assert(stageResp2.Response().StatusCode, chk.Equals, 201)
+	c.Assert(stageResp2.ContentMD5(), chk.Not(chk.Equals), "")
+	c.Assert(stageResp2.RequestID(), chk.Not(chk.Equals), "")
+	c.Assert(stageResp2.Version(), chk.Not(chk.Equals), "")
+	c.Assert(stageResp2.Date().IsZero(), chk.Equals, false)
+	c.Assert(stageResp2.IsServerEncrypted(), chk.Equals, "true")
+
+	blockList, err := destBlob.GetBlockList(ctx, BlockListAll, LeaseAccessConditions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(blockList.Response().StatusCode, chk.Equals, 200)
+	c.Assert(blockList.UncommittedBlocks, chk.HasLen, 2)
+	c.Assert(blockList.CommittedBlocks, chk.HasLen, 0)
+
+	listResp, err := destBlob.CommitBlockList(ctx, []string{blockID1, blockID2}, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultAccessTier, nil, testCPK1)
+	c.Assert(err, chk.IsNil)
+	c.Assert(listResp.Response().StatusCode, chk.Equals, 201)
+	c.Assert(listResp.IsServerEncrypted(), chk.Equals, "true")
+	c.Assert(listResp.EncryptionScope(), chk.Equals, *(testCPK1.EncryptionScope))
+
+	blockList, err = destBlob.GetBlockList(ctx, BlockListAll, LeaseAccessConditions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(blockList.Response().StatusCode, chk.Equals, 200)
+	c.Assert(blockList.UncommittedBlocks, chk.HasLen, 0)
+	c.Assert(blockList.CommittedBlocks, chk.HasLen, 2)
+
+	// Download blob to do data integrity check.
+	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK1)
+	c.Assert(err, chk.IsNil)
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	c.Assert(err, chk.IsNil)
+	c.Assert(destData, chk.DeepEquals, srcData)
+	c.Assert(downloadResp.r.rawResponse.Header.Get("x-ms-encryption-scope"), chk.Equals, *(testCPK1.EncryptionScope))
+}
+
+func (s *aztestsSuite) TestUploadBlobWithMD5WithCPK(c *chk.C) {
+	bsu := getBSU()
+	container, _ := createNewContainer(c, bsu)
+	defer delContainer(c, container)
+
+	testSize := 1 * 1024 * 1024
+	r, srcData := getRandomDataAndReader(testSize)
+	md5Val := md5.Sum(srcData)
+	blobURL := container.NewBlockBlobURL(generateBlobName())
+
+	uploadSrcResp, err := blobURL.Upload(ctx, r, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(uploadSrcResp.Response().StatusCode, chk.Equals, 201)
+
+	// Get blob content without encryption key should fail the request.
+	downloadResp, err := blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+
+	// Download blob to do data integrity check.
+	downloadResp, err = blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(downloadResp.ContentMD5(), chk.DeepEquals, md5Val[:])
+	data, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	c.Assert(err, chk.IsNil)
+	c.Assert(data, chk.DeepEquals, srcData)
+}
+
+func (s *aztestsSuite) TestAppendBlockWithCPK(c *chk.C) {
+	bsu := getBSU()
+	container, _ := createNewContainer(c, bsu)
+	defer delContainer(c, container)
+
+	appendBlobURL := container.NewAppendBlobURL(generateBlobName())
+
+	resp, err := appendBlobURL.Create(context.Background(), BlobHTTPHeaders{}, nil, BlobAccessConditions{}, nil, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.StatusCode(), chk.Equals, 201)
+
+	words := []string{"AAA ", "BBB ", "CCC "}
+	for index, word := range words {
+		resp, err := appendBlobURL.AppendBlock(context.Background(), strings.NewReader(word), AppendBlobAccessConditions{}, nil, testCPK)
+		c.Assert(err, chk.IsNil)
+		c.Assert(err, chk.IsNil)
+		c.Assert(resp.Response().StatusCode, chk.Equals, 201)
+		c.Assert(resp.BlobAppendOffset(), chk.Equals, strconv.Itoa(index*4))
+		c.Assert(resp.BlobCommittedBlockCount(), chk.Equals, int32(index+1))
+		c.Assert(resp.ETag(), chk.Not(chk.Equals), ETagNone)
+		c.Assert(resp.LastModified().IsZero(), chk.Equals, false)
+		c.Assert(resp.ContentMD5(), chk.Not(chk.Equals), "")
+		c.Assert(resp.RequestID(), chk.Not(chk.Equals), "")
+		c.Assert(resp.Version(), chk.Not(chk.Equals), "")
+		c.Assert(resp.Date().IsZero(), chk.Equals, false)
+		c.Assert(resp.IsServerEncrypted(), chk.Equals, "true")
+		c.Assert(resp.EncryptionKeySha256(), chk.Equals, *(testCPK.EncryptionKeySha256))
+	}
+
+	// Get blob content without encryption key should fail the request.
+	_, err = appendBlobURL.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+
+	// Download blob to do data integrity check.
+	downloadResp, err := appendBlobURL.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
+	c.Assert(err, chk.IsNil)
+
+	data, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	c.Assert(err, chk.IsNil)
+	c.Assert(string(data), chk.DeepEquals, "AAA BBB CCC ")
+}
+
+func (s *aztestsSuite) TestAppendBlockWithCPKByScope(c *chk.C) {
+	bsu := getBSU()
+	container, _ := createNewContainer(c, bsu)
+	defer delContainer(c, container)
+
+	appendBlobURL := container.NewAppendBlobURL(generateBlobName())
+
+	resp, err := appendBlobURL.Create(context.Background(), BlobHTTPHeaders{}, nil, BlobAccessConditions{}, nil, testCPK1)
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.StatusCode(), chk.Equals, 201)
+
+	words := []string{"AAA ", "BBB ", "CCC "}
+	for index, word := range words {
+		resp, err := appendBlobURL.AppendBlock(context.Background(), strings.NewReader(word), AppendBlobAccessConditions{}, nil, testCPK1)
+		c.Assert(err, chk.IsNil)
+		c.Assert(err, chk.IsNil)
+		c.Assert(resp.Response().StatusCode, chk.Equals, 201)
+		c.Assert(resp.BlobAppendOffset(), chk.Equals, strconv.Itoa(index*4))
+		c.Assert(resp.BlobCommittedBlockCount(), chk.Equals, int32(index+1))
+		c.Assert(resp.ETag(), chk.Not(chk.Equals), ETagNone)
+		c.Assert(resp.LastModified().IsZero(), chk.Equals, false)
+		c.Assert(resp.ContentMD5(), chk.Not(chk.Equals), "")
+		c.Assert(resp.RequestID(), chk.Not(chk.Equals), "")
+		c.Assert(resp.Version(), chk.Not(chk.Equals), "")
+		c.Assert(resp.Date().IsZero(), chk.Equals, false)
+		c.Assert(resp.IsServerEncrypted(), chk.Equals, "true")
+		c.Assert(resp.EncryptionScope(), chk.Equals, *(testCPK1.EncryptionScope))
+	}
+
+	// Download blob to do data integrity check.
+	downloadResp, err := appendBlobURL.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK1)
+	c.Assert(err, chk.IsNil)
+	c.Assert(downloadResp.IsServerEncrypted(), chk.Equals, "true")
+
+	data, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	c.Assert(err, chk.IsNil)
+	c.Assert(string(data), chk.DeepEquals, "AAA BBB CCC ")
+	c.Assert(downloadResp.r.rawResponse.Header.Get("x-ms-encryption-scope"), chk.Equals, *(testCPK1.EncryptionScope))
+}
+
+func (s *aztestsSuite) TestAppendBlockFromURLWithCPK(c *chk.C) {
+	bsu := getBSU()
+	credential, err := getGenericCredential("")
+	if err != nil {
+		c.Fatal("Invalid credential")
+	}
+	container, _ := createNewContainer(c, bsu)
+	defer delContainer(c, container)
+
+	testSize := 2 * 1024 * 1024 // 2MB
+	r, srcData := getRandomDataAndReader(testSize)
+	ctx := context.Background() // Use default Background context
+	blobURL := container.NewAppendBlobURL(generateName("src"))
+	destBlob := container.NewAppendBlobURL(generateName("dest"))
+
+	cResp1, err := blobURL.Create(context.Background(), BlobHTTPHeaders{}, nil, BlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(cResp1.StatusCode(), chk.Equals, 201)
+
+	resp, err := blobURL.AppendBlock(context.Background(), r, AppendBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.ETag(), chk.Not(chk.Equals), ETagNone)
+	c.Assert(resp.LastModified().IsZero(), chk.Equals, false)
+	c.Assert(resp.ContentMD5(), chk.Not(chk.Equals), "")
+
+	srcBlobParts := NewBlobURLParts(blobURL.URL())
+
+	srcBlobParts.SAS, err = BlobSASSignatureValues{
+		Protocol:      SASProtocolHTTPS,
+		ExpiryTime:    time.Now().UTC().Add(1 * time.Hour),
+		ContainerName: srcBlobParts.ContainerName,
+		BlobName:      srcBlobParts.BlobName,
+		Permissions:   BlobSASPermissions{Read: true}.String(),
+	}.NewSASQueryParameters(credential)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	srcBlobURLWithSAS := srcBlobParts.URL()
+
+	cResp2, err := destBlob.Create(context.Background(), BlobHTTPHeaders{}, nil, BlobAccessConditions{}, nil, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(cResp2.StatusCode(), chk.Equals, 201)
+
+	appendResp, err := destBlob.AppendBlockFromURL(ctx, srcBlobURLWithSAS, 0, int64(testSize), AppendBlobAccessConditions{}, ModifiedAccessConditions{}, nil, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(appendResp.ETag(), chk.Not(chk.Equals), ETagNone)
+	c.Assert(appendResp.LastModified().IsZero(), chk.Equals, false)
+	c.Assert(appendResp.IsServerEncrypted(), chk.Equals, "true")
+
+	// Get blob content without encryption key should fail the request.
+	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+
+	// Download blob to do data integrity check.
+	downloadResp, err = destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
+	c.Assert(err, chk.IsNil)
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	c.Assert(err, chk.IsNil)
+	c.Assert(destData, chk.DeepEquals, srcData)
+}
+
+func (s *aztestsSuite) TestPageBlockWithCPK(c *chk.C) {
+	bsu := getBSU()
+	container, _ := createNewContainer(c, bsu)
+	defer delContainer(c, container)
+
+	testSize := 1 * 1024 * 1024
+	r, srcData := getRandomDataAndReader(testSize)
+	blobURL, _ := createNewPageBlobWithCPK(c, container, int64(testSize), testCPK)
+
+	uploadResp, err := blobURL.UploadPages(ctx, 0, r, PageBlobAccessConditions{}, nil, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(uploadResp.Response().StatusCode, chk.Equals, 201)
+
+	// Get blob content without encryption key should fail the request.
+	downloadResp, err := blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+
+	// Download blob to do data integrity check.
+	downloadResp, err = blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
+	c.Assert(err, chk.IsNil)
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	c.Assert(err, chk.IsNil)
+	c.Assert(destData, chk.DeepEquals, srcData)
+}
+
+func (s *aztestsSuite) TestPageBlockWithCPKByScope(c *chk.C) {
+	bsu := getBSU()
+	container, _ := createNewContainer(c, bsu)
+	// defer delContainer(c, container)
+
+	testSize := 1 * 1024 * 1024
+	r, srcData := getRandomDataAndReader(testSize)
+	blobURL, _ := createNewPageBlobWithCPK(c, container, int64(testSize), testCPK1)
+
+	uploadResp, err := blobURL.UploadPages(ctx, 0, r, PageBlobAccessConditions{}, nil, testCPK1)
+	c.Assert(err, chk.IsNil)
+	c.Assert(uploadResp.Response().StatusCode, chk.Equals, 201)
+	c.Assert(uploadResp.EncryptionScope(), chk.Equals, *(testCPK1.EncryptionScope))
+
+	// Download blob to do data integrity check.
+	downloadResp, err := blobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK1)
+	c.Assert(err, chk.IsNil)
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	c.Assert(err, chk.IsNil)
+	c.Assert(destData, chk.DeepEquals, srcData)
+	c.Assert(downloadResp.r.rawResponse.Header.Get("x-ms-encryption-scope"), chk.Equals, *(testCPK1.EncryptionScope))
+}
+
+func (s *aztestsSuite) TestPageBlockFromURLWithCPK(c *chk.C) {
+	bsu := getBSU()
+	credential, err := getGenericCredential("")
+	if err != nil {
+		c.Fatal("Invalid credential")
+	}
+	container, _ := createNewContainer(c, bsu)
+	defer delContainer(c, container)
+
+	testSize := 1 * 1024 * 1024 // 1MB
+	r, srcData := getRandomDataAndReader(testSize)
+	ctx := context.Background() // Use default Background context
+	blobURL, _ := createNewPageBlobWithSize(c, container, int64(testSize))
+	destBlob, _ := createNewPageBlobWithCPK(c, container, int64(testSize), testCPK)
+
+	uploadResp, err := blobURL.UploadPages(ctx, 0, r, PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(uploadResp.Response().StatusCode, chk.Equals, 201)
+	srcBlobParts := NewBlobURLParts(blobURL.URL())
+
+	srcBlobParts.SAS, err = BlobSASSignatureValues{
+		Protocol:      SASProtocolHTTPS,
+		ExpiryTime:    time.Now().UTC().Add(1 * time.Hour),
+		ContainerName: srcBlobParts.ContainerName,
+		BlobName:      srcBlobParts.BlobName,
+		Permissions:   BlobSASPermissions{Read: true}.String(),
+	}.NewSASQueryParameters(credential)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	srcBlobURLWithSAS := srcBlobParts.URL()
+
+	resp, err := destBlob.UploadPagesFromURL(ctx, srcBlobURLWithSAS, 0, 0, int64(testSize), nil, PageBlobAccessConditions{}, ModifiedAccessConditions{}, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.ETag(), chk.NotNil)
+	c.Assert(resp.LastModified(), chk.NotNil)
+	c.Assert(resp.Response().StatusCode, chk.Equals, 201)
+	c.Assert(resp.IsServerEncrypted(), chk.Equals, "true")
+
+	// Download blob to do data integrity check.
+	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(downloadResp.r.EncryptionKeySha256(), chk.Equals, *(testCPK.EncryptionKeySha256))
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	c.Assert(err, chk.IsNil)
+	c.Assert(destData, chk.DeepEquals, srcData)
+}
+
+func (s *aztestsSuite) TestUploadPagesFromURLWithMD5WithCPK(c *chk.C) {
+	bsu := getBSU()
+	credential, err := getGenericCredential("")
+	if err != nil {
+		c.Fatal("Invalid credential")
+	}
+	container, _ := createNewContainer(c, bsu)
+	defer delContainer(c, container)
+
+	testSize := 1 * 1024 * 1024
+	r, srcData := getRandomDataAndReader(testSize)
+	md5Value := md5.Sum(srcData)
+	srcBlob, _ := createNewPageBlobWithSize(c, container, int64(testSize))
+
+	uploadSrcResp1, err := srcBlob.UploadPages(ctx, 0, r, PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(uploadSrcResp1.Response().StatusCode, chk.Equals, 201)
+
+	srcBlobParts := NewBlobURLParts(srcBlob.URL())
+
+	srcBlobParts.SAS, err = BlobSASSignatureValues{
+		Protocol:      SASProtocolHTTPS,
+		ExpiryTime:    time.Now().UTC().Add(1 * time.Hour),
+		ContainerName: srcBlobParts.ContainerName,
+		BlobName:      srcBlobParts.BlobName,
+		Permissions:   BlobSASPermissions{Read: true}.String(),
+	}.NewSASQueryParameters(credential)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	srcBlobURLWithSAS := srcBlobParts.URL()
+	destBlob, _ := createNewPageBlobWithCPK(c, container, int64(testSize), testCPK)
+	uploadResp, err := destBlob.UploadPagesFromURL(ctx, srcBlobURLWithSAS, 0, 0, int64(testSize), md5Value[:], PageBlobAccessConditions{}, ModifiedAccessConditions{}, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(uploadResp.ETag(), chk.NotNil)
+	c.Assert(uploadResp.LastModified(), chk.NotNil)
+	c.Assert(uploadResp.EncryptionKeySha256(), chk.Equals, *(testCPK.EncryptionKeySha256))
+	c.Assert(uploadResp.ContentMD5(), chk.DeepEquals, md5Value[:])
+	c.Assert(uploadResp.BlobSequenceNumber(), chk.Equals, int64(0))
+
+	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(downloadResp.r.EncryptionKeySha256(), chk.Equals, *(testCPK.EncryptionKeySha256))
+	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
+	c.Assert(err, chk.IsNil)
+	c.Assert(destData, chk.DeepEquals, srcData)
+
+	_, badMD5 := getRandomDataAndReader(16)
+	_, err = destBlob.UploadPagesFromURL(ctx, srcBlobURLWithSAS, 0, 0, int64(testSize), badMD5[:], PageBlobAccessConditions{}, ModifiedAccessConditions{}, ClientProvidedKeyOptions{})
+	validateStorageError(c, err, ServiceCodeMd5Mismatch)
+}
+
+func (s *aztestsSuite) TestGetSetBlobMetadataWithCPK(c *chk.C) {
+	bsu := getBSU()
+	containerURL, _ := createNewContainer(c, bsu)
+	defer deleteContainer(c, containerURL)
+	blobURL, _ := createNewBlockBlobWithCPK(c, containerURL, testCPK)
+
+	metadata := Metadata{"key": "value", "another_key": "1234"}
+
+	// Set blob metadata without encryption key should fail the request.
+	_, err := blobURL.SetMetadata(ctx, metadata, BlobAccessConditions{}, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+
+	resp, err := blobURL.SetMetadata(ctx, metadata, BlobAccessConditions{}, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.EncryptionKeySha256(), chk.Equals, *(testCPK.EncryptionKeySha256))
+
+	// Get blob properties without encryption key should fail the request.
+	getResp, err := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+
+	getResp, err = blobURL.GetProperties(ctx, BlobAccessConditions{}, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(getResp.NewMetadata(), chk.HasLen, 2)
+	c.Assert(getResp.NewMetadata(), chk.DeepEquals, metadata)
+
+	_, err = blobURL.SetMetadata(ctx, Metadata{}, BlobAccessConditions{}, testCPK)
+	c.Assert(err, chk.IsNil)
+
+	getResp, err = blobURL.GetProperties(ctx, BlobAccessConditions{}, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(getResp.NewMetadata(), chk.HasLen, 0)
+}
+
+func (s *aztestsSuite) TestGetSetBlobMetadataWithCPKByScope(c *chk.C) {
+	bsu := getBSU()
+	containerURL, _ := createNewContainer(c, bsu)
+	defer deleteContainer(c, containerURL)
+	blobURL, _ := createNewBlockBlobWithCPK(c, containerURL, testCPK1)
+
+	metadata := Metadata{"key": "value", "another_key": "1234"}
+
+	// Set blob metadata without encryption key should fail the request.
+	_, err := blobURL.SetMetadata(ctx, metadata, BlobAccessConditions{}, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+
+	_, err = blobURL.SetMetadata(ctx, metadata, BlobAccessConditions{}, testCPK1)
+	c.Assert(err, chk.IsNil)
+
+	getResp, err := blobURL.GetProperties(ctx, BlobAccessConditions{}, testCPK1)
+	c.Assert(err, chk.IsNil)
+	c.Assert(getResp.NewMetadata(), chk.HasLen, 2)
+	c.Assert(getResp.NewMetadata(), chk.DeepEquals, metadata)
+
+	_, err = blobURL.SetMetadata(ctx, Metadata{}, BlobAccessConditions{}, testCPK1)
+	c.Assert(err, chk.IsNil)
+
+	getResp, err = blobURL.GetProperties(ctx, BlobAccessConditions{}, testCPK1)
+	c.Assert(err, chk.IsNil)
+	c.Assert(getResp.NewMetadata(), chk.HasLen, 0)
+}
+
+func (s *aztestsSuite) TestBlobSnapshotWithCPK(c *chk.C) {
+	bsu := getBSU()
+	containerURL, _ := createNewContainer(c, bsu)
+	defer deleteContainer(c, containerURL)
+	blobURL, _ := createNewBlockBlobWithCPK(c, containerURL, testCPK)
+	_, err := blobURL.Upload(ctx, strings.NewReader("113333555555"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, testCPK)
+
+	// Create Snapshot of an encrypted blob without encryption key should fail the request.
+	resp, err := blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{}, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+
+	resp, err = blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{}, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.IsServerEncrypted(), chk.Equals, "false")
+	snapshotURL := blobURL.WithSnapshot(resp.Snapshot())
+
+	dResp, err := snapshotURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK)
+	c.Assert(err, chk.IsNil)
+	c.Assert(dResp.r.EncryptionKeySha256(), chk.Equals, *(testCPK.EncryptionKeySha256))
+	_, err = snapshotURL.Delete(ctx, DeleteSnapshotsOptionNone, BlobAccessConditions{})
+	c.Assert(err, chk.IsNil)
+
+	// Get blob properties of snapshot without encryption key should fail the request.
+	_, err = snapshotURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+	c.Assert(err.(StorageError).Response().StatusCode, chk.Equals, 404)
+}
+
+func (s *aztestsSuite) TestBlobSnapshotWithCPKByScope(c *chk.C) {
+	bsu := getBSU()
+	containerURL, _ := createNewContainer(c, bsu)
+	defer deleteContainer(c, containerURL)
+	blobURL, _ := createNewBlockBlobWithCPK(c, containerURL, testCPK)
+	_, err := blobURL.Upload(ctx, strings.NewReader("113333555555"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, testCPK1)
+
+	// Create Snapshot of an encrypted blob without encryption key should fail the request.
+	resp, err := blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{}, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+
+	resp, err = blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{}, testCPK1)
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.IsServerEncrypted(), chk.Equals, "false")
+	snapshotURL := blobURL.WithSnapshot(resp.Snapshot())
+
+	_, err = snapshotURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, testCPK1)
+	c.Assert(err, chk.IsNil)
+	_, err = snapshotURL.Delete(ctx, DeleteSnapshotsOptionNone, BlobAccessConditions{})
+	c.Assert(err, chk.IsNil)
+
+	// Get blob properties of snapshot without encryption key should fail the request.
+	_, err = snapshotURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.NotNil)
+	c.Assert(err.(StorageError).Response().StatusCode, chk.Equals, 404)
+}

--- a/azblob/zt_highlevel_test.go
+++ b/azblob/zt_highlevel_test.go
@@ -42,7 +42,7 @@ func performUploadStreamToBlockBlobTest(c *chk.C, blobSize, bufferSize, maxBuffe
 	c.Assert(uploadResp.Response().StatusCode, chk.Equals, 201)
 
 	// Download the blob to verify
-	downloadResponse, err := blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false)
+	downloadResponse, err := blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	// Assert that the content is correct

--- a/azblob/zt_sas_blob_snapshot_test.go
+++ b/azblob/zt_sas_blob_snapshot_test.go
@@ -24,13 +24,13 @@ func (s *aztestsSuite) TestSnapshotSAS(c *chk.C) {
 	burl := containerURL.NewBlockBlobURL(blobName)
 	data := "Hello world!"
 
-	_, err = burl.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil)
+	_, err = burl.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	if err != nil {
 		c.Fatal(err)
 	}
 
 	//Create a snapshot & URL
-	createSnapshot, err := burl.CreateSnapshot(ctx, Metadata{}, BlobAccessConditions{})
+	createSnapshot, err := burl.CreateSnapshot(ctx, Metadata{}, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func (s *aztestsSuite) TestSnapshotSAS(c *chk.C) {
 	sburl := NewBlockBlobURL(snapParts.URL(), p)
 
 	//Test the snapshot
-	downloadResponse, err := sburl.Download(ctx, 0, 0, BlobAccessConditions{}, false)
+	downloadResponse, err := sburl.Download(ctx, 0, 0, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func (s *aztestsSuite) TestSnapshotSAS(c *chk.C) {
 	//If this succeeds, it means a normal SAS token was created.
 
 	fsburl := containerURL.NewBlockBlobURL("failsnap")
-	_, err = fsburl.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil)
+	_, err = fsburl.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	if err != nil {
 		c.Fatal(err) //should succeed to create the blob via normal auth means
 	}

--- a/azblob/zt_test.go
+++ b/azblob/zt_test.go
@@ -166,7 +166,7 @@ func createNewContainerWithSuffix(c *chk.C, bsu ServiceURL, suffix string) (cont
 func createNewBlockBlob(c *chk.C, container ContainerURL) (blob BlockBlobURL, name string) {
 	blob, name = getBlockBlobURL(c, container)
 
-	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultAccessTier, nil)
+	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.StatusCode(), chk.Equals, 201)
@@ -174,11 +174,30 @@ func createNewBlockBlob(c *chk.C, container ContainerURL) (blob BlockBlobURL, na
 	return
 }
 
+func createNewBlockBlobWithCPK(c *chk.C, container ContainerURL, cpk ClientProvidedKeyOptions) (blob BlockBlobURL, name string) {
+	blob, name = getBlockBlobURL(c, container)
+
+	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), BlobHTTPHeaders{},
+		nil, BlobAccessConditions{}, DefaultAccessTier, nil, cpk)
+	c.Assert(err, chk.IsNil)
+	c.Assert(cResp.StatusCode(), chk.Equals, 201)
+	return
+}
+
 func createNewAppendBlob(c *chk.C, container ContainerURL) (blob AppendBlobURL, name string) {
 	blob, name = getAppendBlobURL(c, container)
 
-	resp, err := blob.Create(ctx, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, nil)
+	resp, err := blob.Create(ctx, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.StatusCode(), chk.Equals, 201)
+	return
+}
+
+func createNewAppendBlobWithCPK(c *chk.C, container ContainerURL, cpk ClientProvidedKeyOptions) (blob AppendBlobURL, name string) {
+	blob, name = getAppendBlobURL(c, container)
+
+	resp, err := blob.Create(ctx, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, nil, cpk)
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.StatusCode(), chk.Equals, 201)
 	return
@@ -187,7 +206,7 @@ func createNewAppendBlob(c *chk.C, container ContainerURL) (blob AppendBlobURL, 
 func createNewPageBlob(c *chk.C, container ContainerURL) (blob PageBlobURL, name string) {
 	blob, name = getPageBlobURL(c, container)
 
-	resp, err := blob.Create(ctx, PageBlobPageBytes*10, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil)
+	resp, err := blob.Create(ctx, PageBlobPageBytes*10, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.StatusCode(), chk.Equals, 201)
 	return
@@ -196,8 +215,16 @@ func createNewPageBlob(c *chk.C, container ContainerURL) (blob PageBlobURL, name
 func createNewPageBlobWithSize(c *chk.C, container ContainerURL, sizeInBytes int64) (blob PageBlobURL, name string) {
 	blob, name = getPageBlobURL(c, container)
 
-	resp, err := blob.Create(ctx, sizeInBytes, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil)
+	resp, err := blob.Create(ctx, sizeInBytes, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil, ClientProvidedKeyOptions{})
+	c.Assert(err, chk.IsNil)
+	c.Assert(resp.StatusCode(), chk.Equals, 201)
+	return
+}
 
+func createNewPageBlobWithCPK(c *chk.C, container ContainerURL, sizeInBytes int64, cpk ClientProvidedKeyOptions) (blob PageBlobURL, name string) {
+	blob, name = getPageBlobURL(c, container)
+
+	resp, err := blob.Create(ctx, sizeInBytes, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil, cpk)
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.StatusCode(), chk.Equals, 201)
 	return
@@ -207,7 +234,7 @@ func createBlockBlobWithPrefix(c *chk.C, container ContainerURL, prefix string) 
 	name = prefix + generateName(blobPrefix)
 	blob = container.NewBlockBlobURL(name)
 
-	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultAccessTier, nil)
+	cResp, err := blob.Upload(ctx, strings.NewReader(blockBlobDefaultData), BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 
 	c.Assert(err, chk.IsNil)
 	c.Assert(cResp.StatusCode(), chk.Equals, 201)
@@ -371,7 +398,7 @@ func disableSoftDelete(c *chk.C, bsu ServiceURL) {
 }
 
 func validateUpload(c *chk.C, blobURL BlockBlobURL) {
-	resp, err := blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false)
+	resp, err := blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	data, _ := ioutil.ReadAll(resp.Response().Body)
 	c.Assert(data, chk.HasLen, 0)

--- a/azblob/zt_url_page_blob_test.go
+++ b/azblob/zt_url_page_blob_test.go
@@ -20,7 +20,7 @@ func (s *aztestsSuite) TestPutGetPages(c *chk.C) {
 	blob, _ := createNewPageBlob(c, container)
 
 	pageRange := PageRange{Start: 0, End: 1023}
-	putResp, err := blob.UploadPages(context.Background(), 0, getReaderToRandomBytes(1024), PageBlobAccessConditions{}, nil)
+	putResp, err := blob.UploadPages(context.Background(), 0, getReaderToRandomBytes(1024), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(putResp.Response().StatusCode, chk.Equals, 201)
 	c.Assert(putResp.LastModified().IsZero(), chk.Equals, false)
@@ -60,7 +60,7 @@ func (s *aztestsSuite) TestUploadPagesFromURL(c *chk.C) {
 	destBlob, _ := createNewPageBlobWithSize(c, container, int64(testSize))
 
 	// Prepare source blob for copy.
-	uploadSrcResp1, err := srcBlob.UploadPages(ctx, 0, r, PageBlobAccessConditions{}, nil)
+	uploadSrcResp1, err := srcBlob.UploadPages(ctx, 0, r, PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadSrcResp1.Response().StatusCode, chk.Equals, 201)
 
@@ -81,7 +81,7 @@ func (s *aztestsSuite) TestUploadPagesFromURL(c *chk.C) {
 	srcBlobURLWithSAS := srcBlobParts.URL()
 
 	// Upload page from URL.
-	pResp1, err := destBlob.UploadPagesFromURL(ctx, srcBlobURLWithSAS, 0, 0, int64(testSize), nil, PageBlobAccessConditions{}, ModifiedAccessConditions{})
+	pResp1, err := destBlob.UploadPagesFromURL(ctx, srcBlobURLWithSAS, 0, 0, int64(testSize), nil, PageBlobAccessConditions{}, ModifiedAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(pResp1.ETag(), chk.NotNil)
 	c.Assert(pResp1.LastModified(), chk.NotNil)
@@ -92,7 +92,7 @@ func (s *aztestsSuite) TestUploadPagesFromURL(c *chk.C) {
 	c.Assert(pResp1.Date().IsZero(), chk.Equals, false)
 
 	// Check data integrity through downloading.
-	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false)
+	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
 	c.Assert(err, chk.IsNil)
@@ -116,7 +116,7 @@ func (s *aztestsSuite) TestUploadPagesFromURLWithMD5(c *chk.C) {
 	destBlob, _ := createNewPageBlobWithSize(c, container, int64(testSize))
 
 	// Prepare source blob for copy.
-	uploadSrcResp1, err := srcBlob.UploadPages(ctx, 0, r, PageBlobAccessConditions{}, nil)
+	uploadSrcResp1, err := srcBlob.UploadPages(ctx, 0, r, PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(uploadSrcResp1.Response().StatusCode, chk.Equals, 201)
 
@@ -137,7 +137,7 @@ func (s *aztestsSuite) TestUploadPagesFromURLWithMD5(c *chk.C) {
 	srcBlobURLWithSAS := srcBlobParts.URL()
 
 	// Upload page from URL with MD5.
-	pResp1, err := destBlob.UploadPagesFromURL(ctx, srcBlobURLWithSAS, 0, 0, int64(testSize), md5Value[:], PageBlobAccessConditions{}, ModifiedAccessConditions{})
+	pResp1, err := destBlob.UploadPagesFromURL(ctx, srcBlobURLWithSAS, 0, 0, int64(testSize), md5Value[:], PageBlobAccessConditions{}, ModifiedAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(pResp1.ETag(), chk.NotNil)
 	c.Assert(pResp1.LastModified(), chk.NotNil)
@@ -149,7 +149,7 @@ func (s *aztestsSuite) TestUploadPagesFromURLWithMD5(c *chk.C) {
 	c.Assert(pResp1.BlobSequenceNumber(), chk.Equals, int64(0))
 
 	// Check data integrity through downloading.
-	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false)
+	downloadResp, err := destBlob.BlobURL.Download(ctx, 0, CountToEnd, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	destData, err := ioutil.ReadAll(downloadResp.Body(RetryReaderOptions{}))
 	c.Assert(err, chk.IsNil)
@@ -157,7 +157,7 @@ func (s *aztestsSuite) TestUploadPagesFromURLWithMD5(c *chk.C) {
 
 	// Upload page from URL with bad MD5
 	_, badMD5 := getRandomDataAndReader(16)
-	_, err = destBlob.UploadPagesFromURL(ctx, srcBlobURLWithSAS, 0, 0, int64(testSize), badMD5[:], PageBlobAccessConditions{}, ModifiedAccessConditions{})
+	_, err = destBlob.UploadPagesFromURL(ctx, srcBlobURLWithSAS, 0, 0, int64(testSize), badMD5[:], PageBlobAccessConditions{}, ModifiedAccessConditions{}, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeMd5Mismatch)
 }
 
@@ -167,13 +167,13 @@ func (s *aztestsSuite) TestClearDiffPages(c *chk.C) {
 	defer delContainer(c, container)
 
 	blob, _ := createNewPageBlob(c, container)
-	_, err := blob.UploadPages(context.Background(), 0, getReaderToRandomBytes(2048), PageBlobAccessConditions{}, nil)
+	_, err := blob.UploadPages(context.Background(), 0, getReaderToRandomBytes(2048), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
-	snapshotResp, err := blob.CreateSnapshot(context.Background(), nil, BlobAccessConditions{})
+	snapshotResp, err := blob.CreateSnapshot(context.Background(), nil, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
-	_, err = blob.UploadPages(context.Background(), 2048, getReaderToRandomBytes(2048), PageBlobAccessConditions{}, nil)
+	_, err = blob.UploadPages(context.Background(), 2048, getReaderToRandomBytes(2048), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	pageList, err := blob.GetPageRangesDiff(context.Background(), 0, 4096, snapshotResp.Snapshot(), BlobAccessConditions{})
@@ -182,7 +182,7 @@ func (s *aztestsSuite) TestClearDiffPages(c *chk.C) {
 	c.Assert(pageList.PageRange[0].Start, chk.Equals, int64(2048))
 	c.Assert(pageList.PageRange[0].End, chk.Equals, int64(4095))
 
-	clearResp, err := blob.ClearPages(context.Background(), 2048, 2048, PageBlobAccessConditions{})
+	clearResp, err := blob.ClearPages(context.Background(), 2048, 2048, PageBlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(clearResp.Response().StatusCode, chk.Equals, 201)
 
@@ -199,9 +199,9 @@ func (s *aztestsSuite) TestIncrementalCopy(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 
 	srcBlob, _ := createNewPageBlob(c, container)
-	_, err = srcBlob.UploadPages(context.Background(), 0, getReaderToRandomBytes(1024), PageBlobAccessConditions{}, nil)
+	_, err = srcBlob.UploadPages(context.Background(), 0, getReaderToRandomBytes(1024), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
-	snapshotResp, err := srcBlob.CreateSnapshot(context.Background(), nil, BlobAccessConditions{})
+	snapshotResp, err := srcBlob.CreateSnapshot(context.Background(), nil, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	dstBlob := container.NewPageBlobURL(generateBlobName())
@@ -226,15 +226,15 @@ func (s *aztestsSuite) TestResizePageBlob(c *chk.C) {
 	defer delContainer(c, container)
 
 	blob, _ := createNewPageBlob(c, container)
-	resp, err := blob.Resize(context.Background(), 2048, BlobAccessConditions{})
+	resp, err := blob.Resize(context.Background(), 2048, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.Response().StatusCode, chk.Equals, 200)
 
-	resp, err = blob.Resize(context.Background(), 8192, BlobAccessConditions{})
+	resp, err = blob.Resize(context.Background(), 8192, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.Response().StatusCode, chk.Equals, 200)
 
-	resp2, err := blob.GetProperties(ctx, BlobAccessConditions{})
+	resp2, err := blob.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp2.ContentLength(), chk.Equals, int64(8192))
 }
@@ -269,7 +269,7 @@ func (s *aztestsSuite) TestPutPagesWithMD5(c *chk.C) {
 	// put page with valid MD5
 	readerToBody, body := getRandomDataAndReader(1024)
 	md5Value := md5.Sum(body)
-	putResp, err := blob.UploadPages(context.Background(), 0, readerToBody, PageBlobAccessConditions{}, md5Value[:])
+	putResp, err := blob.UploadPages(context.Background(), 0, readerToBody, PageBlobAccessConditions{}, md5Value[:], ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(putResp.Response().StatusCode, chk.Equals, 201)
 	c.Assert(putResp.LastModified().IsZero(), chk.Equals, false)
@@ -283,7 +283,7 @@ func (s *aztestsSuite) TestPutPagesWithMD5(c *chk.C) {
 	// put page with bad MD5
 	readerToBody, body = getRandomDataAndReader(1024)
 	_, badMD5 := getRandomDataAndReader(16)
-	putResp, err = blob.UploadPages(context.Background(), 0, readerToBody, PageBlobAccessConditions{}, badMD5[:])
+	putResp, err = blob.UploadPages(context.Background(), 0, readerToBody, PageBlobAccessConditions{}, badMD5[:], ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeMd5Mismatch)
 }
 
@@ -293,7 +293,7 @@ func (s *aztestsSuite) TestBlobCreatePageSizeInvalid(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.Create(ctx, 1, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil)
+	_, err := blobURL.Create(ctx, 1, 0, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeInvalidHeaderValue)
 }
 
@@ -303,7 +303,7 @@ func (s *aztestsSuite) TestBlobCreatePageSequenceInvalid(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, -1, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, -1, BlobHTTPHeaders{}, nil, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.Not(chk.IsNil))
 }
 
@@ -313,9 +313,9 @@ func (s *aztestsSuite) TestBlobCreatePageMetadataNonEmpty(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil, ClientProvidedKeyOptions{})
 
-	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.NewMetadata(), chk.DeepEquals, basicMetadata)
 }
@@ -326,9 +326,9 @@ func (s *aztestsSuite) TestBlobCreatePageMetadataEmpty(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultPremiumBlobAccessTier, nil, ClientProvidedKeyOptions{})
 
-	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.NewMetadata(), chk.HasLen, 0)
 }
@@ -339,7 +339,7 @@ func (s *aztestsSuite) TestBlobCreatePageMetadataInvalid(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, Metadata{"In valid1": "bar"}, BlobAccessConditions{}, PremiumPageBlobAccessTierNone, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, Metadata{"In valid1": "bar"}, BlobAccessConditions{}, PremiumPageBlobAccessTierNone, nil, ClientProvidedKeyOptions{})
 	c.Assert(strings.Contains(err.Error(), invalidHeaderErrorSubstring), chk.Equals, true)
 
 }
@@ -350,17 +350,17 @@ func (s *aztestsSuite) TestBlobCreatePageHTTPHeaders(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, basicHeaders, nil, BlobAccessConditions{}, PremiumPageBlobAccessTierNone, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, basicHeaders, nil, BlobAccessConditions{}, PremiumPageBlobAccessTierNone, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
-	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	h := resp.NewHTTPHeaders()
 	c.Assert(h, chk.DeepEquals, basicHeaders)
 }
 
 func validatePageBlobPut(c *chk.C, blobURL PageBlobURL) {
-	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.NewMetadata(), chk.DeepEquals, basicMetadata)
 }
@@ -373,7 +373,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfModifiedSinceTrue(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(-10)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, DefaultPremiumBlobAccessTier, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, DefaultPremiumBlobAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validatePageBlobPut(c, blobURL)
@@ -387,7 +387,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfModifiedSinceFalse(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(10)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, DefaultPremiumBlobAccessTier, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, DefaultPremiumBlobAccessTier, nil, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -399,7 +399,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfUnmodifiedSinceTrue(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(10)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, DefaultPremiumBlobAccessTier, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, DefaultPremiumBlobAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validatePageBlobPut(c, blobURL)
@@ -413,7 +413,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfUnmodifiedSinceFalse(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(-10)
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, DefaultPremiumBlobAccessTier, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, DefaultPremiumBlobAccessTier, nil, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -423,9 +423,9 @@ func (s *aztestsSuite) TestBlobCreatePageIfMatchTrue(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL) // Originally created without metadata
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}}, PremiumPageBlobAccessTierNone, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}}, PremiumPageBlobAccessTierNone, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validatePageBlobPut(c, blobURL)
@@ -437,7 +437,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfMatchFalse(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL) // Originally created without metadata
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: ETag("garbage")}}, PremiumPageBlobAccessTierNone, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: ETag("garbage")}}, PremiumPageBlobAccessTierNone, nil, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -447,7 +447,7 @@ func (s *aztestsSuite) TestBlobCreatePageIfNoneMatchTrue(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL) // Originally created without metadata
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETag("garbage")}}, PremiumPageBlobAccessTierNone, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETag("garbage")}}, PremiumPageBlobAccessTierNone, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validatePageBlobPut(c, blobURL)
@@ -459,9 +459,9 @@ func (s *aztestsSuite) TestBlobCreatePageIfNoneMatchFalse(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL) // Originally created without metadata
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
-	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}}, DefaultPremiumBlobAccessTier, nil)
+	_, err := blobURL.Create(ctx, PageBlobPageBytes, 0, BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}}, DefaultPremiumBlobAccessTier, nil, ClientProvidedKeyOptions{})
 
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
@@ -472,7 +472,7 @@ func (s *aztestsSuite) TestBlobPutPagesInvalidRange(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, strings.NewReader(blockBlobDefaultData), PageBlobAccessConditions{}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, strings.NewReader(blockBlobDefaultData), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.Not(chk.IsNil))
 }
 
@@ -482,7 +482,7 @@ func (s *aztestsSuite) TestBlobPutPagesNilBody(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, nil, PageBlobAccessConditions{}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, nil, PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.Not(chk.IsNil))
 }
 
@@ -492,7 +492,7 @@ func (s *aztestsSuite) TestBlobPutPagesEmptyBody(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, bytes.NewReader([]byte{}), PageBlobAccessConditions{}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, bytes.NewReader([]byte{}), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.Not(chk.IsNil))
 }
 
@@ -502,7 +502,7 @@ func (s *aztestsSuite) TestBlobPutPagesNonExistantBlob(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := getPageBlobURL(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeBlobNotFound)
 }
 
@@ -521,8 +521,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfModifiedSinceTrue(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(-10)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateUploadPages(c, blobURL)
@@ -536,8 +535,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfModifiedSinceFalse(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(10)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, nil, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -549,8 +547,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfUnmodifiedSinceTrue(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(10)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateUploadPages(c, blobURL)
@@ -564,8 +561,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfUnmodifiedSinceFalse(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(-10)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, nil, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -575,10 +571,9 @@ func (s *aztestsSuite) TestBlobPutPagesIfMatchTrue(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateUploadPages(c, blobURL)
@@ -590,8 +585,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfMatchFalse(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: ETag("garbage")}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: ETag("garbage")}}, nil, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -601,8 +595,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfNoneMatchTrue(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETag("garbage")}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETag("garbage")}}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateUploadPages(c, blobURL)
@@ -614,10 +607,9 @@ func (s *aztestsSuite) TestBlobPutPagesIfNoneMatchFalse(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}}, nil, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -627,8 +619,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfSequenceNumberLessThanTrue(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThan: 10}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThan: 10}}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateUploadPages(c, blobURL)
@@ -641,8 +632,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfSequenceNumberLessThanFalse(c *chk.C) {
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
 	blobURL.UpdateSequenceNumber(ctx, SequenceNumberActionUpdate, 10, BlobAccessConditions{})
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThan: 1}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThan: 1}}, nil, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeSequenceNumberConditionNotMet)
 }
 
@@ -652,8 +642,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfSequenceNumberLessThanNegOne(c *chk.C) 
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThan: -1}}, nil) // This will cause the library to set the value of the header to 0
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThan: -1}}, nil, ClientProvidedKeyOptions{}) // This will cause the library to set the value of the header to 0
 	validateStorageError(c, err, ServiceCodeSequenceNumberConditionNotMet)
 }
 
@@ -664,8 +653,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfSequenceNumberLTETrue(c *chk.C) {
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
 	blobURL.UpdateSequenceNumber(ctx, SequenceNumberActionUpdate, 1, BlobAccessConditions{})
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThanOrEqual: 1}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThanOrEqual: 1}}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateUploadPages(c, blobURL)
@@ -678,8 +666,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfSequenceNumberLTEqualFalse(c *chk.C) {
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
 	blobURL.UpdateSequenceNumber(ctx, SequenceNumberActionUpdate, 10, BlobAccessConditions{})
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThanOrEqual: 1}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThanOrEqual: 1}}, nil, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeSequenceNumberConditionNotMet)
 }
 
@@ -689,8 +676,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfSequenceNumberLTENegOne(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThanOrEqual: -1}}, nil) // This will cause the library to set the value of the header to 0
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThanOrEqual: -1}}, nil, ClientProvidedKeyOptions{}) // This will cause the library to set the value of the header to 0
 	c.Assert(err, chk.IsNil)
 
 	validateUploadPages(c, blobURL)
@@ -703,8 +689,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfSequenceNumberEqualTrue(c *chk.C) {
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
 	blobURL.UpdateSequenceNumber(ctx, SequenceNumberActionUpdate, 1, BlobAccessConditions{})
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberEqual: 1}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberEqual: 1}}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateUploadPages(c, blobURL)
@@ -716,8 +701,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfSequenceNumberEqualFalse(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberEqual: 1}}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberEqual: 1}}, nil, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeSequenceNumberConditionNotMet)
 }
 
@@ -727,8 +711,7 @@ func (s *aztestsSuite) TestBlobPutPagesIfSequenceNumberEqualNegOne(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes),
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberEqual: -1}}, nil) // This will cause the library to set the value of the header to 0
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberEqual: -1}}, nil, ClientProvidedKeyOptions{}) // This will cause the library to set the value of the header to 0
 	c.Assert(err, chk.IsNil)
 
 	validateUploadPages(c, blobURL)
@@ -739,7 +722,7 @@ func setupClearPagesTest(c *chk.C) (ContainerURL, PageBlobURL) {
 	containerURL, _ := createNewContainer(c, bsu)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	return containerURL, blobURL
@@ -755,7 +738,7 @@ func (s *aztestsSuite) TestBlobClearPagesInvalidRange(c *chk.C) {
 	containerURL, blobURL := setupClearPagesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes+1, PageBlobAccessConditions{})
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes+1, PageBlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.Not(chk.IsNil))
 }
 
@@ -765,8 +748,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfModifiedSinceTrue(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(-10)
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}})
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateClearPagesTest(c, blobURL)
@@ -778,8 +760,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfModifiedSinceFalse(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(10)
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}})
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -789,8 +770,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfUnmodifiedSinceTrue(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(10)
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}})
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateClearPagesTest(c, blobURL)
@@ -802,8 +782,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfUnmodifiedSinceFalse(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(-10)
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}})
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -811,10 +790,9 @@ func (s *aztestsSuite) TestBlobClearPagesIfMatchTrue(c *chk.C) {
 	containerURL, blobURL := setupClearPagesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}})
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateClearPagesTest(c, blobURL)
@@ -824,8 +802,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfMatchFalse(c *chk.C) {
 	containerURL, blobURL := setupClearPagesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: ETag("garbage")}})
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: ETag("garbage")}}, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -833,8 +810,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfNoneMatchTrue(c *chk.C) {
 	containerURL, blobURL := setupClearPagesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETag("garbage")}})
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETag("garbage")}}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateClearPagesTest(c, blobURL)
@@ -844,10 +820,9 @@ func (s *aztestsSuite) TestBlobClearPagesIfNoneMatchFalse(c *chk.C) {
 	containerURL, blobURL := setupClearPagesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}})
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}}, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -855,8 +830,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfSequenceNumberLessThanTrue(c *chk.C) 
 	containerURL, blobURL := setupClearPagesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThan: 10}})
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThan: 10}}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateClearPagesTest(c, blobURL)
@@ -868,8 +842,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfSequenceNumberLessThanFalse(c *chk.C)
 
 	_, err := blobURL.UpdateSequenceNumber(ctx, SequenceNumberActionUpdate, 10, BlobAccessConditions{})
 	c.Assert(err, chk.IsNil)
-	_, err = blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThan: 1}})
+	_, err = blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThan: 1}}, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeSequenceNumberConditionNotMet)
 }
 
@@ -877,8 +850,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfSequenceNumberLessThanNegOne(c *chk.C
 	containerURL, blobURL := setupClearPagesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThan: -1}}) // This will cause the library to set the value of the header to 0
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThan: -1}}, ClientProvidedKeyOptions{}) // This will cause the library to set the value of the header to 0
 	validateStorageError(c, err, ServiceCodeSequenceNumberConditionNotMet)
 }
 
@@ -886,8 +858,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfSequenceNumberLTETrue(c *chk.C) {
 	containerURL, blobURL := setupClearPagesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThanOrEqual: 10}})
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThanOrEqual: 10}}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateClearPagesTest(c, blobURL)
@@ -899,8 +870,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfSequenceNumberLTEFalse(c *chk.C) {
 
 	_, err := blobURL.UpdateSequenceNumber(ctx, SequenceNumberActionUpdate, 10, BlobAccessConditions{})
 	c.Assert(err, chk.IsNil)
-	_, err = blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThanOrEqual: 1}})
+	_, err = blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThanOrEqual: 1}}, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeSequenceNumberConditionNotMet)
 }
 
@@ -908,8 +878,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfSequenceNumberLTENegOne(c *chk.C) {
 	containerURL, blobURL := setupClearPagesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThanOrEqual: -1}}) // This will cause the library to set the value of the header to 0
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberLessThanOrEqual: -1}}, ClientProvidedKeyOptions{}) // This will cause the library to set the value of the header to 0
 	c.Assert(err, chk.IsNil)
 
 	validateClearPagesTest(c, blobURL)
@@ -921,8 +890,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfSequenceNumberEqualTrue(c *chk.C) {
 
 	_, err := blobURL.UpdateSequenceNumber(ctx, SequenceNumberActionUpdate, 10, BlobAccessConditions{})
 	c.Assert(err, chk.IsNil)
-	_, err = blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberEqual: 10}})
+	_, err = blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberEqual: 10}}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateClearPagesTest(c, blobURL)
@@ -934,8 +902,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfSequenceNumberEqualFalse(c *chk.C) {
 
 	_, err := blobURL.UpdateSequenceNumber(ctx, SequenceNumberActionUpdate, 10, BlobAccessConditions{})
 	c.Assert(err, chk.IsNil)
-	_, err = blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberEqual: 1}})
+	_, err = blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberEqual: 1}}, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeSequenceNumberConditionNotMet)
 }
 
@@ -943,8 +910,7 @@ func (s *aztestsSuite) TestBlobClearPagesIfSequenceNumberEqualNegOne(c *chk.C) {
 	containerURL, blobURL := setupClearPagesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes,
-		PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberEqual: -1}}) // This will cause the library to set the value of the header to 0
+	_, err := blobURL.ClearPages(ctx, 0, PageBlobPageBytes, PageBlobAccessConditions{SequenceNumberAccessConditions: SequenceNumberAccessConditions{IfSequenceNumberEqual: -1}}, ClientProvidedKeyOptions{}) // This will cause the library to set the value of the header to 0
 	c.Assert(err, chk.IsNil)
 
 	validateClearPagesTest(c, blobURL)
@@ -955,7 +921,7 @@ func setupGetPageRangesTest(c *chk.C) (containerURL ContainerURL, blobURL PageBl
 	containerURL, _ = createNewContainer(c, bsu)
 	blobURL, _ = createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	return
@@ -998,7 +964,7 @@ func (s *aztestsSuite) TestBlobGetPageRangesNonContiguousRanges(c *chk.C) {
 	containerURL, blobURL := setupGetPageRangesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, PageBlobPageBytes*2, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{}, nil)
+	_, err := blobURL.UploadPages(ctx, PageBlobPageBytes*2, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	resp, err := blobURL.GetPageRanges(ctx, 0, 0, BlobAccessConditions{})
 	c.Assert(err, chk.IsNil)
@@ -1019,7 +985,7 @@ func (s *aztestsSuite) TestBlobGetPageRangesSnapshot(c *chk.C) {
 	containerURL, blobURL := setupGetPageRangesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	resp, _ := blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{})
+	resp, _ := blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	snapshotURL := blobURL.WithSnapshot(resp.Snapshot())
 	resp2, err := snapshotURL.GetPageRanges(ctx, 0, 0, BlobAccessConditions{})
 	c.Assert(err, chk.IsNil)
@@ -1075,7 +1041,7 @@ func (s *aztestsSuite) TestBlobGetPageRangesIfMatchTrue(c *chk.C) {
 	containerURL, blobURL := setupGetPageRangesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
 	resp2, err := blobURL.GetPageRanges(ctx, 0, 0,
 		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}})
@@ -1104,7 +1070,7 @@ func (s *aztestsSuite) TestBlobGetPageRangesIfNoneMatchFalse(c *chk.C) {
 	containerURL, blobURL := setupGetPageRangesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
 	_, err := blobURL.GetPageRanges(ctx, 0, 0,
 		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}})
@@ -1117,14 +1083,14 @@ func setupDiffPageRangesTest(c *chk.C) (containerURL ContainerURL, blobURL PageB
 	containerURL, _ = createNewContainer(c, bsu)
 	blobURL, _ = createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{}, nil)
+	_, err := blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
-	resp, err := blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{})
+	resp, err := blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	snapshot = resp.Snapshot()
 
-	_, err = blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{}, nil)
+	_, err = blobURL.UploadPages(ctx, 0, getReaderToRandomBytes(PageBlobPageBytes), PageBlobAccessConditions{}, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil) // This ensures there is a diff on the first page
 	return
 }
@@ -1202,7 +1168,7 @@ func (s *aztestsSuite) TestBlobDiffPageRangeIfMatchTrue(c *chk.C) {
 	containerURL, blobURL, snapshot := setupDiffPageRangesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
 	resp2, err := blobURL.GetPageRangesDiff(ctx, 0, 0, snapshot,
 		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}})
@@ -1231,7 +1197,7 @@ func (s *aztestsSuite) TestBlobDiffPageRangeIfNoneMatchFalse(c *chk.C) {
 	containerURL, blobURL, snapshot := setupDiffPageRangesTest(c)
 	defer deleteContainer(c, containerURL)
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
 	_, err := blobURL.GetPageRangesDiff(ctx, 0, 0, snapshot,
 		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}})
@@ -1246,10 +1212,10 @@ func (s *aztestsSuite) TestBlobResizeZero(c *chk.C) {
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
 	// The default blob is created with size > 0, so this should actually update
-	_, err := blobURL.Resize(ctx, 0, BlobAccessConditions{})
+	_, err := blobURL.Resize(ctx, 0, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
-	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.ContentLength(), chk.Equals, int64(0))
 }
@@ -1260,7 +1226,7 @@ func (s *aztestsSuite) TestBlobResizeInvalidSizeNegative(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.Resize(ctx, -4, BlobAccessConditions{})
+	_, err := blobURL.Resize(ctx, -4, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.Not(chk.IsNil))
 }
 
@@ -1270,12 +1236,12 @@ func (s *aztestsSuite) TestBlobResizeInvalidSizeMisaligned(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.Resize(ctx, 12, BlobAccessConditions{})
+	_, err := blobURL.Resize(ctx, 12, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.Not(chk.IsNil))
 }
 
 func validateResize(c *chk.C, blobURL PageBlobURL) {
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(resp.ContentLength(), chk.Equals, int64(PageBlobPageBytes))
 }
 
@@ -1287,8 +1253,7 @@ func (s *aztestsSuite) TestBlobResizeIfModifiedSinceTrue(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(-10)
 
-	_, err := blobURL.Resize(ctx, PageBlobPageBytes,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}})
+	_, err := blobURL.Resize(ctx, PageBlobPageBytes, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateResize(c, blobURL)
@@ -1302,8 +1267,7 @@ func (s *aztestsSuite) TestBlobResizeIfModifiedSinceFalse(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(10)
 
-	_, err := blobURL.Resize(ctx, PageBlobPageBytes,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}})
+	_, err := blobURL.Resize(ctx, PageBlobPageBytes, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfModifiedSince: currentTime}}, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -1315,8 +1279,7 @@ func (s *aztestsSuite) TestBlobResizeIfUnmodifiedSinceTrue(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(10)
 
-	_, err := blobURL.Resize(ctx, PageBlobPageBytes,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}})
+	_, err := blobURL.Resize(ctx, PageBlobPageBytes, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateResize(c, blobURL)
@@ -1330,8 +1293,7 @@ func (s *aztestsSuite) TestBlobResizeIfUnmodifiedSinceFalse(c *chk.C) {
 
 	currentTime := getRelativeTimeGMT(-10)
 
-	_, err := blobURL.Resize(ctx, PageBlobPageBytes,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}})
+	_, err := blobURL.Resize(ctx, PageBlobPageBytes, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfUnmodifiedSince: currentTime}}, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -1341,10 +1303,9 @@ func (s *aztestsSuite) TestBlobResizeIfMatchTrue(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
-	_, err := blobURL.Resize(ctx, PageBlobPageBytes,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}})
+	_, err := blobURL.Resize(ctx, PageBlobPageBytes, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateResize(c, blobURL)
@@ -1356,8 +1317,7 @@ func (s *aztestsSuite) TestBlobResizeIfMatchFalse(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.Resize(ctx, PageBlobPageBytes,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: ETag("garbage")}})
+	_, err := blobURL.Resize(ctx, PageBlobPageBytes, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: ETag("garbage")}}, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -1367,8 +1327,7 @@ func (s *aztestsSuite) TestBlobResizeIfNoneMatchTrue(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	_, err := blobURL.Resize(ctx, PageBlobPageBytes,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETag("garbage")}})
+	_, err := blobURL.Resize(ctx, PageBlobPageBytes, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: ETag("garbage")}}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 
 	validateResize(c, blobURL)
@@ -1380,10 +1339,9 @@ func (s *aztestsSuite) TestBlobResizeIfNoneMatchFalse(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
-	_, err := blobURL.Resize(ctx, PageBlobPageBytes,
-		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}})
+	_, err := blobURL.Resize(ctx, PageBlobPageBytes, BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}}, ClientProvidedKeyOptions{})
 	validateStorageError(c, err, ServiceCodeConditionNotMet)
 }
 
@@ -1411,7 +1369,7 @@ func (s *aztestsSuite) TestBlobSetSequenceNumberSequenceNumberInvalid(c *chk.C) 
 }
 
 func validateSequenceNumberSet(c *chk.C, blobURL PageBlobURL) {
-	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, err := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.BlobSequenceNumber(), chk.Equals, int64(1))
 }
@@ -1478,7 +1436,7 @@ func (s *aztestsSuite) TestBlobSetSequenceNumberIfMatchTrue(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
 	_, err := blobURL.UpdateSequenceNumber(ctx, SequenceNumberActionIncrement, 0,
 		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}})
@@ -1517,7 +1475,7 @@ func (s *aztestsSuite) TestBlobSetSequenceNumberIfNoneMatchFalse(c *chk.C) {
 	defer deleteContainer(c, containerURL)
 	blobURL, _ := createNewPageBlob(c, containerURL)
 
-	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := blobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
 	_, err := blobURL.UpdateSequenceNumber(ctx, SequenceNumberActionIncrement, 0,
 		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}})
@@ -1530,7 +1488,7 @@ func waitForIncrementalCopy(c *chk.C, copyBlobURL PageBlobURL, blobCopyResponse 
 	// Wait for the copy to finish
 	start := time.Now()
 	for status != CopyStatusSuccess {
-		getPropertiesAndMetadataResult, _ = copyBlobURL.GetProperties(ctx, BlobAccessConditions{})
+		getPropertiesAndMetadataResult, _ = copyBlobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 		status = getPropertiesAndMetadataResult.CopyStatus()
 		currentTime := time.Now()
 		if currentTime.Sub(start) >= time.Minute {
@@ -1545,7 +1503,7 @@ func setupStartIncrementalCopyTest(c *chk.C) (containerURL ContainerURL, blobURL
 	containerURL, _ = createNewContainer(c, bsu)
 	containerURL.SetAccessPolicy(ctx, PublicAccessBlob, nil, ContainerAccessConditions{})
 	blobURL, _ = createNewPageBlob(c, containerURL)
-	resp, _ := blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{})
+	resp, _ := blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	copyBlobURL, _ = getPageBlobURL(c, containerURL)
 
 	// Must create the incremental copy blob so that the access conditions work on it
@@ -1553,7 +1511,7 @@ func setupStartIncrementalCopyTest(c *chk.C) (containerURL ContainerURL, blobURL
 	c.Assert(err, chk.IsNil)
 	waitForIncrementalCopy(c, copyBlobURL, resp2)
 
-	resp, _ = blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{}) // Take a new snapshot so the next copy will succeed
+	resp, _ = blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{}, ClientProvidedKeyOptions{}) // Take a new snapshot so the next copy will succeed
 	snapshot = resp.Snapshot()
 	return
 }
@@ -1563,7 +1521,7 @@ func validateIncrementalCopy(c *chk.C, copyBlobURL PageBlobURL, resp *PageBlobCo
 
 	// If we can access the snapshot without error, we are satisfied that it was created as a result of the copy
 	copySnapshotURL := copyBlobURL.WithSnapshot(t)
-	_, err := copySnapshotURL.GetProperties(ctx, BlobAccessConditions{})
+	_, err := copySnapshotURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 }
 
@@ -1636,7 +1594,7 @@ func (s *aztestsSuite) TestBlobStartIncrementalCopyIfMatchTrue(c *chk.C) {
 
 	defer deleteContainer(c, containerURL)
 
-	resp, _ := copyBlobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := copyBlobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
 	resp2, err := copyBlobURL.StartCopyIncremental(ctx, blobURL.URL(), snapshot,
 		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: resp.ETag()}})
@@ -1672,7 +1630,7 @@ func (s *aztestsSuite) TestBlobStartIncrementalCopyIfNoneMatchFalse(c *chk.C) {
 
 	defer deleteContainer(c, containerURL)
 
-	resp, _ := copyBlobURL.GetProperties(ctx, BlobAccessConditions{})
+	resp, _ := copyBlobURL.GetProperties(ctx, BlobAccessConditions{}, ClientProvidedKeyOptions{})
 
 	_, err := copyBlobURL.StartCopyIncremental(ctx, blobURL.URL(), snapshot,
 		BlobAccessConditions{ModifiedAccessConditions: ModifiedAccessConditions{IfNoneMatch: resp.ETag()}})

--- a/azblob/zt_url_service_test.go
+++ b/azblob/zt_url_service_test.go
@@ -27,7 +27,7 @@ func (s *aztestsSuite) TestGetAccountInfo(c *chk.C) {
 
 	// test on a block blob URL. They all call the same thing on the base URL, so only one test is needed for that.
 	bbURL := cURL.NewBlockBlobURL(generateBlobName())
-	_, err = bbURL.Upload(ctx, strings.NewReader("blah"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil)
+	_, err = bbURL.Upload(ctx, strings.NewReader("blah"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	bAccInfo, err := bbURL.GetAccountInfo(ctx)
 	c.Assert(err, chk.IsNil)

--- a/azblob/zt_user_delegation_sas_test.go
+++ b/azblob/zt_user_delegation_sas_test.go
@@ -56,12 +56,12 @@ func (s *aztestsSuite) TestUserDelegationSASContainer(c *chk.C) {
 	cSASURL := NewContainerURL(cURL, p)
 
 	bblob := cSASURL.NewBlockBlobURL("test")
-	_, err = bblob.Upload(ctx, strings.NewReader("hello world!"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil)
+	_, err = bblob.Upload(ctx, strings.NewReader("hello world!"), BlobHTTPHeaders{}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	if err != nil {
 		c.Fatal(err)
 	}
 
-	resp, err := bblob.Download(ctx, 0, 0, BlobAccessConditions{}, false)
+	resp, err := bblob.Download(ctx, 0, 0, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	data := &bytes.Buffer{}
 	body := resp.Body(RetryReaderOptions{})
 	if body == nil {
@@ -134,13 +134,13 @@ func (s *aztestsSuite) TestUserDelegationSASBlob(c *chk.C) {
 		c.Fatal(err)
 	}
 	data := "Hello World!"
-	_, err = blobURL.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil)
+	_, err = blobURL.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	if err != nil {
 		c.Fatal(err)
 	}
 
 	// Download data via User Delegation SAS URL; must succeed
-	downloadResponse, err := bSASURL.Download(ctx, 0, 0, BlobAccessConditions{}, false)
+	downloadResponse, err := bSASURL.Download(ctx, 0, 0, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/azblob/zz_response_helpers.go
+++ b/azblob/zz_response_helpers.go
@@ -63,11 +63,9 @@ func (r *DownloadResponse) Body(o RetryReaderOptions) io.ReadCloser {
 	}
 	return NewRetryReader(r.ctx, r.Response(), r.getInfo, o,
 		func(ctx context.Context, getInfo HTTPGetterInfo) (*http.Response, error) {
-			resp, err := r.b.Download(ctx, getInfo.Offset, getInfo.Count,
-				BlobAccessConditions{
-					ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: getInfo.ETag},
-				},
-				false)
+			resp, err := r.b.Download(ctx, getInfo.Offset, getInfo.Count, BlobAccessConditions{
+				ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: getInfo.ETag},
+			}, false, ClientProvidedKeyOptions{})
 			if err != nil {
 				return nil, err
 			}

--- a/azblob/zz_response_helpers.go
+++ b/azblob/zz_response_helpers.go
@@ -65,7 +65,7 @@ func (r *DownloadResponse) Body(o RetryReaderOptions) io.ReadCloser {
 		func(ctx context.Context, getInfo HTTPGetterInfo) (*http.Response, error) {
 			resp, err := r.b.Download(ctx, getInfo.Offset, getInfo.Count, BlobAccessConditions{
 				ModifiedAccessConditions: ModifiedAccessConditions{IfMatch: getInfo.ETag},
-			}, false, ClientProvidedKeyOptions{})
+			}, false, o.ClientProvidedKeyOptions)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Azure Storage automatically encrypts data (including metadata) stored in its cloud. Azure use AES256 scheme to encrypt/decrypt the data. Customer Provided Key (Name/Value) will facilitate request level encryption thereby giving granular control over encryption. 
For more info, please see [Encryption](https://docs.microsoft.com/en-us/azure/storage/common/storage-service-encryption)

Azure Storage supports following operations support sending customer-provided encryption keys on a request:
Put Blob, Put Block List, Put Block, Put Block from URL, Put Page, Put Page from URL, Append Block, Set Blob Properties, Set Blob Metadata, Get Blob, Get Blob Properties, Get Blob Metadata, Snapshot Blob.
For more info, please see [CPK](https://docs.microsoft.com/en-us/azure/storage/common/encryption-customer-provided-keys)