### PR TITLE
fix: chunkwriter hangs on cancel

### DIFF
--- a/azblob/chunkwriting_test.go
+++ b/azblob/chunkwriting_test.go
@@ -40,6 +40,8 @@ func newFakeBlockWriter() *fakeBlockWriter {
 func (f *fakeBlockWriter) StageBlock(ctx context.Context, blockID string, r io.ReadSeeker, cond LeaseAccessConditions, md5 []byte) (*BlockBlobStageBlockResponse, error) {
 	n := atomic.AddInt32(&f.block, 1)
 	if n == f.errOnBlock {
+		// simulate activity
+		time.Sleep(100 * time.Millisecond)
 		return nil, io.ErrNoProgress
 	}
 
@@ -204,6 +206,13 @@ func TestCopyFromReader(t *testing.T) {
 			desc:     "Send file(1.5 MiB) with default UploadStreamToBlockBlobOptions",
 			ctx:      context.Background(),
 			fileSize: _1MiB + 500*1024,
+		},
+		{
+			desc:      "Send file(12 MiB) with default UploadStreamToBlockBlobOptions and a write error",
+			ctx:       context.Background(),
+			fileSize:  12 * _1MiB,
+			uploadErr: true,
+			err:       true,
 		},
 		{
 			desc:     "Send file(1.5 MiB) with 2 writers",


### PR DESCRIPTION
Chunkwriter `copyFromReader` will hang when canceling in response to a StageBlock error. `sendChunk` blocks on writing to the channel, but the writers exit on cancel without draining the channel. 

This change allows `sendChunk` to exit with an error in this scenario, rather than block on channel write.

Test added to repro.