### PR TITLE
chunkwriting: custom buffer pool

### DIFF
--- a/azblob/chunkwriting_test.go
+++ b/azblob/chunkwriting_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -230,6 +231,16 @@ func TestCopyFromReader(t *testing.T) {
 			ctx:      context.Background(),
 			fileSize: 12 * _1MiB,
 			o:        UploadStreamToBlockBlobOptions{MaxBuffers: 5, BufferSize: 8 * 1024 * 1024},
+		},
+		{
+			desc:     "Send file(1 MiB) with custom BufferPool",
+			ctx:      context.Background(),
+			fileSize: 1 * _1MiB,
+			o:        UploadStreamToBlockBlobOptions{MaxBuffers: 5, SyncPool: &sync.Pool{
+				New: func() interface{} {
+					return make([]byte, 1024)
+				},
+			}},
 		},
 	}
 

--- a/azblob/highlevel.go
+++ b/azblob/highlevel.go
@@ -366,6 +366,8 @@ const _1MiB = 1024 * 1024
 type UploadStreamToBlockBlobOptions struct {
 	// BufferSize sizes the buffer used to read data from source. If < 1 MiB, defaults to 1 MiB.
 	BufferSize int
+	// SyncPool if provided excludes BufferSize option. Use one of the two options.
+	SyncPool         BufferPool
 	// MaxBuffers defines the number of simultaneous uploads will be performed to upload the file.
 	MaxBuffers               int
 	BlobHTTPHeaders          BlobHTTPHeaders


### PR DESCRIPTION
Add option to `UploadStreamToBlockBlob` to specify custom pool for buffers.

This is needed to, for example, reuse pool between transfers.

Relates to #233 because with custom pool memory consumption remains constant.