### PR TITLE
Supporting User Delegation SAS

### DIFF
--- a/azblob/sas_service.go
+++ b/azblob/sas_service.go
@@ -88,6 +88,9 @@ func (v BlobSASSignatureValues) NewSASQueryParameters(credential StorageAccountC
 			udkExpiry,
 			udk.SignedService,
 			udk.SignedVersion,
+			udk.SignedAuthOid,
+			udk.SignedUnauthOid,
+			udk.SignedCorrelationId,
 		}, "\n")
 	}
 

--- a/azblob/zt_user_delegation_sas_test.go
+++ b/azblob/zt_user_delegation_sas_test.go
@@ -1,8 +1,14 @@
 package azblob
 
-// TODO: This test will be addressed, it is failing due to a service change
+import (
+	"bytes"
+	chk "gopkg.in/check.v1"
+	"strings"
+	"time"
+)
+
 //Creates a container and tests permissions by listing blobs
-/*func (s *aztestsSuite) TestUserDelegationSASContainer(c *chk.C) {
+func (s *aztestsSuite) TestUserDelegationSASContainer(c *chk.C) {
 	bsu := getBSU()
 	containerURL, containerName := getContainerURL(c, bsu)
 	currentTime := time.Now().UTC()
@@ -74,11 +80,10 @@ package azblob
 	if err != nil {
 		c.Fatal(err)
 	}
-}*/
+}
 
-// TODO: This test will be addressed, it is failing due to a service change
 // Creates a blob, takes a snapshot, downloads from snapshot, and deletes from the snapshot w/ the token
-/*func (s *aztestsSuite) TestUserDelegationSASBlob(c *chk.C) {
+func (s *aztestsSuite) TestUserDelegationSASBlob(c *chk.C) {
 	// Accumulate prerequisite details to create storage etc.
 	bsu := getBSU()
 	containerURL, containerName := getContainerURL(c, bsu)
@@ -155,4 +160,4 @@ package azblob
 	if err != nil {
 		c.Fatal(err)
 	}
-}*/
+}

--- a/azblob/zz_generated_models.go
+++ b/azblob/zz_generated_models.go
@@ -7430,9 +7430,11 @@ type UserDelegationKey struct {
 	SignedVersion string `xml:"SignedVersion"`
 	// Value - The key as a base64 string
 	Value string `xml:"Value"`
-	// SignedAuthOid - The
-	SignedAuthOid       string `xml:"SignedAuthOid"`
-	SignedUnauthOid     string `xml:"SignedUnauthOid"`
+	// SignedAuthOid - The AAD object ID of an authorized user
+	SignedAuthOid string `xml:"SignedAuthOid"`
+	// SignedUnauthOid - The AAD object ID of an unauthorized user
+	SignedUnauthOid string `xml:"SignedUnauthOid"`
+	// SignedCorrelationId - The correlation ID is used to correlate storage audit log
 	SignedCorrelationId string `xml:"SignedCorrelationId"`
 }
 

--- a/azblob/zz_generated_models.go
+++ b/azblob/zz_generated_models.go
@@ -7430,6 +7430,10 @@ type UserDelegationKey struct {
 	SignedVersion string `xml:"SignedVersion"`
 	// Value - The key as a base64 string
 	Value string `xml:"Value"`
+	// SignedAuthOid - The
+	SignedAuthOid       string `xml:"SignedAuthOid"`
+	SignedUnauthOid     string `xml:"SignedUnauthOid"`
+	SignedCorrelationId string `xml:"SignedCorrelationId"`
 }
 
 // MarshalXML implements the xml.Marshaler interface for UserDelegationKey.
@@ -7571,14 +7575,17 @@ func (c *base64Encoded) UnmarshalText(data []byte) error {
 
 // internal type used for marshalling
 type userDelegationKey struct {
-	rawResponse   *http.Response
-	SignedOid     string      `xml:"SignedOid"`
-	SignedTid     string      `xml:"SignedTid"`
-	SignedStart   timeRFC3339 `xml:"SignedStart"`
-	SignedExpiry  timeRFC3339 `xml:"SignedExpiry"`
-	SignedService string      `xml:"SignedService"`
-	SignedVersion string      `xml:"SignedVersion"`
-	Value         string      `xml:"Value"`
+	rawResponse         *http.Response
+	SignedOid           string      `xml:"SignedOid"`
+	SignedTid           string      `xml:"SignedTid"`
+	SignedStart         timeRFC3339 `xml:"SignedStart"`
+	SignedExpiry        timeRFC3339 `xml:"SignedExpiry"`
+	SignedService       string      `xml:"SignedService"`
+	SignedVersion       string      `xml:"SignedVersion"`
+	Value               string      `xml:"Value"`
+	SignedAuthOid       string      `xml:"SignedAuthOid"`
+	SignedUnauthOid     string      `xml:"SignedUnauthOid"`
+	SignedCorrelationId string      `xml:"SignedCorrelationId"`
 }
 
 // internal type used for marshalling


### PR DESCRIPTION
Added Support for User Delegation SAS:

- Added _SignedAuthOid_, _SignedUnauthOid_, and _SignedCorrelationId_ to _UserDelegationKeys_ in **zz_generated_models.go**
-  Updated signedIndentifier with new UDK parameters in **sas_service.go**
- Added back the tests for user delegation sas in **zt_user_delegation_sas_test.go**