### PR TITLE
Keep compatibility with Go 1.13.14.

### DIFF
--- a/azblob/zc_policy_unique_request_id.go
+++ b/azblob/zc_policy_unique_request_id.go
@@ -22,7 +22,8 @@ func NewUniqueRequestIDPolicyFactory() pipeline.Factory {
 			resp, err := next.Do(ctx, request)
 
 			if err == nil && resp != nil {
-				if resp.Response().Header.Get(xMsClientRequestID) != id {
+				crId := resp.Response().Header.Get(xMsClientRequestID)
+				if crId != "" && crId != id {
 					err = errors.New("client Request ID from request and response does not match")
 				}
 			}

--- a/azblob/zc_policy_unique_request_id.go
+++ b/azblob/zc_policy_unique_request_id.go
@@ -3,6 +3,7 @@ package azblob
 import (
 	"context"
 	"errors"
+
 	"github.com/Azure/azure-pipeline-go/pipeline"
 )
 
@@ -21,11 +22,8 @@ func NewUniqueRequestIDPolicyFactory() pipeline.Factory {
 			resp, err := next.Do(ctx, request)
 
 			if err == nil && resp != nil {
-				val := resp.Response().Header.Values(xMsClientRequestID)
-				if len(val) > 0 {
-					if val[0] != id {
-						err = errors.New("client Request ID from request and response does not match")
-					}
+				if resp.Response().Header.Get(xMsClientRequestID) != id {
+					err = errors.New("client Request ID from request and response does not match")
 				}
 			}
 

--- a/azblob/zt_policy_request_id_test.go
+++ b/azblob/zt_policy_request_id_test.go
@@ -3,10 +3,11 @@ package azblob
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-pipeline-go/pipeline"
-	chk "gopkg.in/check.v1"
 	"net/http"
 	"net/url"
+
+	"github.com/Azure/azure-pipeline-go/pipeline"
+	chk "gopkg.in/check.v1"
 )
 
 type requestIDTestScenario int
@@ -58,7 +59,7 @@ func (s *aztestsSuite) TestEchoClientRequestIDMissing(c *chk.C) {
 
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp, chk.NotNil)
-	c.Assert(resp.Response().Header.Values(xMsClientRequestID), chk.IsNil)
+	c.Assert(resp.Response().Header.Get(xMsClientRequestID), chk.Equals, "")
 }
 
 func (s *aztestsSuite) TestEchoClientRequestIDErrorFromNextPolicy(c *chk.C) {


### PR DESCRIPTION
`http.Header` has no method `Values` on older go versions. azblob 0.13 broke the compatibility with Go 1.13.