### PR TITLE
Reverting changes to GetTags/SetTags & BlobPropertiesInternal

### DIFF
--- a/azblob/url_blob.go
+++ b/azblob/url_blob.go
@@ -146,15 +146,15 @@ func (b BlobURL) Delete(ctx context.Context, deleteOptions DeleteSnapshotsOption
 // Each call to this operation replaces all existing tags attached to the blob.
 // To remove all tags from the blob, call this operation with no tags set.
 // https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-tags
-func (b BlobURL) SetTags(ctx context.Context, timeout *int32, versionID *string, transactionalContentMD5 []byte, transactionalContentCrc64 []byte, requestID *string, ifTags *string, blobTagsMap BlobTagsMap) (*BlobSetTagsResponse, error) {
+func (b BlobURL) SetTags(ctx context.Context, transactionalContentMD5 []byte, transactionalContentCrc64 []byte, ifTags *string, blobTagsMap BlobTagsMap) (*BlobSetTagsResponse, error) {
 	tags := SerializeBlobTags(blobTagsMap)
-	return b.blobClient.SetTags(ctx, timeout, versionID, transactionalContentMD5, transactionalContentCrc64, requestID, ifTags, nil, &tags)
+	return b.blobClient.SetTags(ctx, nil, nil, transactionalContentMD5, transactionalContentCrc64, nil, ifTags, nil, &tags)
 }
 
 // GetTags operation enables users to get tags on a blob or specific blob version, or snapshot.
 // https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-tags
-func (b BlobURL) GetTags(ctx context.Context, timeout *int32, requestID *string, snapshot *string, versionID *string, ifTags *string) (*BlobTags, error) {
-	return b.blobClient.GetTags(ctx, timeout, requestID, snapshot, versionID, ifTags, nil)
+func (b BlobURL) GetTags(ctx context.Context, ifTags *string) (*BlobTags, error) {
+	return b.blobClient.GetTags(ctx, nil, nil, nil, nil, ifTags, nil)
 }
 
 // Undelete restores the contents and metadata of a soft-deleted blob and any associated soft-deleted snapshots.

--- a/azblob/zt_blob_tags_test.go
+++ b/azblob/zt_blob_tags_test.go
@@ -27,11 +27,11 @@ func (s *aztestsSuite) TestSetBlobTags(c *chk.C) {
 	blockBlobUploadResp, err := blobURL.Upload(ctx, bytes.NewReader([]byte("data")), BlobHTTPHeaders{}, basicMetadata, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.StatusCode(), chk.Equals, 201)
-	blobSetTagsResponse, err := blobURL.SetTags(ctx, nil, nil, nil, nil, nil, nil, blobTagsMap)
+	blobSetTagsResponse, err := blobURL.SetTags(ctx, nil, nil, nil, blobTagsMap)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobSetTagsResponse.StatusCode(), chk.Equals, 204)
 
-	blobGetTagsResponse, err := blobURL.GetTags(ctx, nil, nil, nil, nil, nil)
+	blobGetTagsResponse, err := blobURL.GetTags(ctx, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobGetTagsResponse.StatusCode(), chk.Equals, 200)
 	c.Assert(blobGetTagsResponse.BlobTagSet, chk.HasLen, 3)
@@ -61,11 +61,11 @@ func (s *aztestsSuite) TestSetBlobTagsWithVID(c *chk.C) {
 	versionId2 := blockBlobUploadResp.VersionID()
 
 	blobURL1 := blobURL.WithVersionID(versionId1)
-	blobSetTagsResponse, err := blobURL1.SetTags(ctx, nil, nil, nil, nil, nil, nil, blobTagsMap)
+	blobSetTagsResponse, err := blobURL1.SetTags(ctx, nil, nil, nil, blobTagsMap)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobSetTagsResponse.StatusCode(), chk.Equals, 204)
 
-	blobGetTagsResponse, err := blobURL1.GetTags(ctx, nil, nil, nil, nil, nil)
+	blobGetTagsResponse, err := blobURL1.GetTags(ctx, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobGetTagsResponse.StatusCode(), chk.Equals, 200)
 	c.Assert(blobGetTagsResponse.BlobTagSet, chk.HasLen, 3)
@@ -74,7 +74,7 @@ func (s *aztestsSuite) TestSetBlobTagsWithVID(c *chk.C) {
 	}
 
 	blobURL2 := blobURL.WithVersionID(versionId2)
-	blobGetTagsResponse, err = blobURL2.GetTags(ctx, nil, nil, nil, nil, nil)
+	blobGetTagsResponse, err = blobURL2.GetTags(ctx, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobGetTagsResponse.StatusCode(), chk.Equals, 200)
 	c.Assert(blobGetTagsResponse.BlobTagSet, chk.IsNil)
@@ -103,11 +103,11 @@ func (s *aztestsSuite) TestSetBlobTagsWithVID2(c *chk.C) {
 	}
 
 	blobURL1 := blobURL.WithVersionID(versionId1)
-	blobSetTagsResponse, err := blobURL1.SetTags(ctx, nil, nil, nil, nil, nil, nil, blobTags1)
+	blobSetTagsResponse, err := blobURL1.SetTags(ctx, nil, nil, nil, blobTags1)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobSetTagsResponse.StatusCode(), chk.Equals, 204)
 
-	blobGetTagsResponse, err := blobURL1.GetTags(ctx, nil, nil, nil, nil, nil)
+	blobGetTagsResponse, err := blobURL1.GetTags(ctx, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobGetTagsResponse.StatusCode(), chk.Equals, 200)
 	c.Assert(blobGetTagsResponse.BlobTagSet, chk.HasLen, 3)
@@ -121,11 +121,11 @@ func (s *aztestsSuite) TestSetBlobTagsWithVID2(c *chk.C) {
 	}
 
 	blobURL2 := blobURL.WithVersionID(versionId2)
-	blobSetTagsResponse, err = blobURL2.SetTags(ctx, nil, nil, nil, nil, nil, nil, blobTags2)
+	blobSetTagsResponse, err = blobURL2.SetTags(ctx, nil, nil, nil, blobTags2)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobSetTagsResponse.StatusCode(), chk.Equals, 204)
 
-	blobGetTagsResponse, err = blobURL2.GetTags(ctx, nil, nil, nil, nil, nil)
+	blobGetTagsResponse, err = blobURL2.GetTags(ctx, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobGetTagsResponse.StatusCode(), chk.Equals, 200)
 	c.Assert(blobGetTagsResponse.BlobTagSet, chk.NotNil)
@@ -148,7 +148,7 @@ func (s *aztestsSuite) TestUploadBlockBlobWithSpecialCharactersInTags(c *chk.C) 
 	c.Assert(err, chk.IsNil)
 	c.Assert(blockBlobUploadResp.StatusCode(), chk.Equals, 201)
 
-	blobGetTagsResponse, err := blobURL.GetTags(ctx, nil, nil, nil, nil, nil)
+	blobGetTagsResponse, err := blobURL.GetTags(ctx, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobGetTagsResponse.StatusCode(), chk.Equals, 200)
 	c.Assert(blobGetTagsResponse.BlobTagSet, chk.HasLen, 3)
@@ -198,7 +198,7 @@ func (s *aztestsSuite) TestStageBlockWithTags(c *chk.C) {
 	c.Assert(contentData, chk.DeepEquals, []uint8(strings.Join(data, "")))
 
 	blobURL1 := blobURL.WithVersionID(versionId)
-	blobGetTagsResp, err := blobURL1.GetTags(ctx, nil, nil, nil, nil, nil)
+	blobGetTagsResp, err := blobURL1.GetTags(ctx, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobGetTagsResp, chk.NotNil)
 	c.Assert(blobGetTagsResp.BlobTagSet, chk.HasLen, 3)
@@ -206,7 +206,7 @@ func (s *aztestsSuite) TestStageBlockWithTags(c *chk.C) {
 		c.Assert(blobTagsMap[blobTag.Key], chk.Equals, blobTag.Value)
 	}
 
-	blobGetTagsResp, err = blobURL.GetTags(ctx, nil, nil, nil, nil, nil)
+	blobGetTagsResp, err = blobURL.GetTags(ctx, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobGetTagsResp, chk.NotNil)
 	c.Assert(blobGetTagsResp.BlobTagSet, chk.HasLen, 3)
@@ -290,7 +290,7 @@ func (s *aztestsSuite) TestStageBlockFromURLWithTags(c *chk.C) {
 	c.Assert(err, chk.IsNil)
 	c.Assert(destData, chk.DeepEquals, sourceData)
 
-	blobGetTagsResp, err := destBlob.GetTags(ctx, nil, nil, nil, nil, nil)
+	blobGetTagsResp, err := destBlob.GetTags(ctx, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobGetTagsResp.BlobTagSet, chk.HasLen, 3)
 	for _, blobTag := range blobGetTagsResp.BlobTagSet {
@@ -402,7 +402,7 @@ func (s *aztestsSuite) TestSetBlobTagForSnapshot(c *chk.C) {
 		"Storage+SDK":     "SDK/GO",
 		"GO ":             ".Net",
 	}
-	_, err := blobURL.SetTags(ctx, nil, nil, nil, nil, nil, nil, blobTagsMap)
+	_, err := blobURL.SetTags(ctx, nil, nil, nil, blobTagsMap)
 	c.Assert(err, chk.IsNil)
 
 	resp, err := blobURL.CreateSnapshot(ctx, nil, BlobAccessConditions{}, ClientProvidedKeyOptions{})
@@ -433,7 +433,7 @@ func (s *aztestsSuite) TestCreatePageBlobWithTags(c *chk.C) {
 	c.Assert(putResp.Version(), chk.Not(chk.Equals), "")
 	c.Assert(putResp.rawResponse.Header.Get("x-ms-version-id"), chk.NotNil)
 
-	setTagResp, err := blob.SetTags(ctx, nil, nil, nil, nil, nil, nil, blobTagsMap)
+	setTagResp, err := blob.SetTags(ctx, nil, nil, nil, blobTagsMap)
 	c.Assert(err, chk.IsNil)
 	c.Assert(setTagResp.StatusCode(), chk.Equals, 204)
 
@@ -447,7 +447,7 @@ func (s *aztestsSuite) TestCreatePageBlobWithTags(c *chk.C) {
 		"b0l1o2b3":   "s0d1k2",
 	}
 
-	setTagResp, err = blob.SetTags(ctx, nil, nil, nil, nil, nil, nil, modifiedBlobTags)
+	setTagResp, err = blob.SetTags(ctx, nil, nil, nil, modifiedBlobTags)
 	c.Assert(err, chk.IsNil)
 	c.Assert(setTagResp.StatusCode(), chk.Equals, 204)
 
@@ -482,7 +482,7 @@ func (s *aztestsSuite) TestSetTagOnPageBlob(c *chk.C) {
 		"b0l1o2b3":   "s0d1k2",
 	}
 
-	setTagResp, err := blob.SetTags(ctx, nil, nil, nil, nil, nil, nil, modifiedBlobTags)
+	setTagResp, err := blob.SetTags(ctx, nil, nil, nil, modifiedBlobTags)
 	c.Assert(err, chk.IsNil)
 	c.Assert(setTagResp.StatusCode(), chk.Equals, 204)
 
@@ -519,7 +519,7 @@ func (s *aztestsSuite) TestListBlobReturnsTags(c *chk.C) {
 		"tag2":     "+-./:=_",
 		"+-./:=_1": "+-./:=_",
 	}
-	resp, err := blobURL.SetTags(ctx, nil, nil, nil, nil, nil, nil, blobTagsMap)
+	resp, err := blobURL.SetTags(ctx, nil, nil, nil, blobTagsMap)
 	c.Assert(err, chk.IsNil)
 	c.Assert(resp.StatusCode(), chk.Equals, 204)
 
@@ -632,11 +632,11 @@ func (s *aztestsSuite) TestFilterBlobsUsingAccountSAS(c *chk.C) {
 	}
 
 	blobTagsMap := BlobTagsMap{"tag1": "firsttag", "tag2": "secondtag", "tag3": "thirdtag"}
-	setBlobTagsResp, err := blobURL.SetTags(ctx, nil, nil, nil, nil, nil, nil, blobTagsMap)
+	setBlobTagsResp, err := blobURL.SetTags(ctx, nil, nil, nil, blobTagsMap)
 	c.Assert(err, chk.IsNil)
 	c.Assert(setBlobTagsResp.StatusCode(), chk.Equals, 204)
 
-	blobGetTagsResp, err := blobURL.GetTags(ctx, nil, nil, nil, nil, nil)
+	blobGetTagsResp, err := blobURL.GetTags(ctx, nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobGetTagsResp.StatusCode(), chk.Equals, 200)
 	c.Assert(blobGetTagsResp.BlobTagSet, chk.HasLen, 3)

--- a/azblob/zt_examples_test.go
+++ b/azblob/zt_examples_test.go
@@ -6,12 +6,14 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"fmt"
+	"github.com/Azure/go-autorest/autorest/adal"
 	"io"
 	"log"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -1300,5 +1302,133 @@ func ExampleListBlobsHierarchy() {
 		if err != nil {
 			log.Fatal("an error occurred while deleting the blobs created by the example")
 		}
+	}
+}
+
+func fetchMSIToken(applicationID string, identityResourceID string, resource string, callbacks ...adal.TokenRefreshCallback) (*adal.ServicePrincipalToken, error) {
+	// Both application id and identityResourceId cannot be present at the same time.
+	if applicationID != "" && identityResourceID != "" {
+		return nil, fmt.Errorf("didn't expect applicationID and identityResourceID at same time")
+	}
+
+	// msiEndpoint is the well known endpoint for getting MSI authentications tokens
+	// msiEndpoint := "http://169.254.169.254/metadata/identity/oauth2/token" for production Jobs
+	msiEndpoint, _ := adal.GetMSIVMEndpoint()
+
+	var spt *adal.ServicePrincipalToken
+	var err error
+
+	// both can be empty, systemAssignedMSI scenario
+	if applicationID == "" && identityResourceID == "" {
+		spt, err = adal.NewServicePrincipalTokenFromMSI(msiEndpoint, resource, callbacks...)
+	}
+
+	// msi login with clientID
+	if applicationID != "" {
+		spt, err = adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint, resource, applicationID, callbacks...)
+	}
+
+	// msi login with resourceID
+	if identityResourceID != "" {
+		spt, err = adal.NewServicePrincipalTokenFromMSIWithIdentityResourceID(msiEndpoint, resource, identityResourceID, callbacks...)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return spt, spt.Refresh()
+}
+
+func getOAuthToken(applicationID, identityResourceID, resource string, callbacks ...adal.TokenRefreshCallback) (*TokenCredential, error) {
+	spt, err := fetchMSIToken(applicationID, identityResourceID, resource, callbacks...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Refresh obtains a fresh token
+	err = spt.Refresh()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tc := NewTokenCredential(spt.Token().AccessToken, func(tc TokenCredential) time.Duration {
+		err := spt.Refresh()
+		if err != nil {
+			// something went wrong, prevent the refresher from being triggered again
+			return 0
+		}
+
+		// set the new token value
+		tc.SetToken(spt.Token().AccessToken)
+
+		// get the next token slightly before the current one expires
+		return time.Until(spt.Token().Expires()) - 10*time.Second
+	})
+
+	return &tc, nil
+}
+
+func ExampleMSILogin() {
+	var accountName string
+	// Use the azure resource id of user assigned identity when creating the token.
+	// identityResourceID := "/subscriptions/{subscriptionID}/resourceGroups/testGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity"
+	// resource := "https://resource"
+	var applicationID, identityResourceID, resource string
+	var err error
+
+	callbacks := func(token adal.Token) error { return nil }
+
+	tokenCredentials, err := getOAuthToken(applicationID, identityResourceID, resource, callbacks)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Create pipeline to handle requests
+	p := NewPipeline(*tokenCredentials, PipelineOptions{})
+	blobPrimaryURL, _ := url.Parse("https://" + accountName + ".blob.core.windows.net/")
+	// Generate a blob service URL
+	bsu := NewServiceURL(*blobPrimaryURL, p)
+
+	// Create container & upload sample data
+	containerName := generateContainerName()
+	containerURL := bsu.NewContainerURL(containerName)
+	_, err = containerURL.Create(ctx, Metadata{}, PublicAccessNone)
+	defer containerURL.Delete(ctx, ContainerAccessConditions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Inside the container, create a test blob with random data.
+	blobName := generateBlobName()
+	blobURL := containerURL.NewBlockBlobURL(blobName)
+	data := "Hello World!"
+	uploadResp, err := blobURL.Upload(ctx, strings.NewReader(data), BlobHTTPHeaders{ContentType: "text/plain"}, Metadata{}, BlobAccessConditions{}, DefaultAccessTier, nil, ClientProvidedKeyOptions{})
+	if err != nil || uploadResp.StatusCode() != 201 {
+		log.Fatal(err)
+	}
+
+	// Download data via User Delegation SAS URL; must succeed
+	downloadResp, err := blobURL.Download(ctx, 0, 0, BlobAccessConditions{}, false, ClientProvidedKeyOptions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	downloadedData := &bytes.Buffer{}
+	reader := downloadResp.Body(RetryReaderOptions{})
+	_, err = downloadedData.ReadFrom(reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = reader.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Verify the content
+	reflect.DeepEqual(data, downloadedData)
+
+	// Delete the item using the User Delegation SAS URL; must succeed
+	_, err = blobURL.Delete(ctx, DeleteSnapshotsOptionInclude, BlobAccessConditions{})
+	if err != nil {
+		log.Fatal(err)
 	}
 }

--- a/azblob/zz_generated_models.go
+++ b/azblob/zz_generated_models.go
@@ -2358,16 +2358,16 @@ type BlobHierarchyListSegment struct {
 // BlobItemInternal - An Azure Storage blob
 type BlobItemInternal struct {
 	// XMLName is used for marshalling and is subject to removal in a future release.
-	XMLName                   xml.Name               `xml:"Blob"`
-	Name                      string                 `xml:"Name"`
-	Deleted                   bool                   `xml:"Deleted"`
-	Snapshot                  string                 `xml:"Snapshot"`
-	VersionID                 *string                `xml:"VersionId"`
-	IsCurrentVersion          *bool                  `xml:"IsCurrentVersion"`
-	Properties                BlobPropertiesInternal `xml:"Properties"`
-	Metadata                  Metadata               `xml:"Metadata"`
-	BlobTags                  *BlobTags              `xml:"Tags"`
-	ObjectReplicationMetadata map[string]string      `xml:"ObjectReplicationMetadata"`
+	XMLName                   xml.Name          `xml:"Blob"`
+	Name                      string            `xml:"Name"`
+	Deleted                   bool              `xml:"Deleted"`
+	Snapshot                  string            `xml:"Snapshot"`
+	VersionID                 *string           `xml:"VersionId"`
+	IsCurrentVersion          *bool             `xml:"IsCurrentVersion"`
+	Properties                BlobProperties    `xml:"Properties"`
+	Metadata                  Metadata          `xml:"Metadata"`
+	BlobTags                  *BlobTags         `xml:"Tags"`
+	ObjectReplicationMetadata map[string]string `xml:"ObjectReplicationMetadata"`
 }
 
 // BlobMetadata ...
@@ -2384,8 +2384,8 @@ type BlobPrefix struct {
 	Name string `xml:"Name"`
 }
 
-// BlobPropertiesInternal - Properties of a blob
-type BlobPropertiesInternal struct {
+// BlobProperties - Properties of a blob
+type BlobProperties struct {
 	// XMLName is used for marshalling and is subject to removal in a future release.
 	XMLName      xml.Name   `xml:"Properties"`
 	CreationTime *time.Time `xml:"Creation-Time"`
@@ -2438,14 +2438,14 @@ type BlobPropertiesInternal struct {
 }
 
 // MarshalXML implements the xml.Marshaler interface for BlobPropertiesInternal.
-func (bpi BlobPropertiesInternal) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	bpi2 := (*blobPropertiesInternal)(unsafe.Pointer(&bpi))
+func (bpi BlobProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	bpi2 := (*blobProperties)(unsafe.Pointer(&bpi))
 	return e.EncodeElement(*bpi2, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaler interface for BlobPropertiesInternal.
-func (bpi *BlobPropertiesInternal) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	bpi2 := (*blobPropertiesInternal)(unsafe.Pointer(bpi))
+func (bpi *BlobProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	bpi2 := (*blobProperties)(unsafe.Pointer(bpi))
 	return d.DecodeElement(bpi2, &start)
 }
 
@@ -7499,7 +7499,7 @@ func init() {
 	if reflect.TypeOf((*AccessPolicy)(nil)).Elem().Size() != reflect.TypeOf((*accessPolicy)(nil)).Elem().Size() {
 		validateError(errors.New("size mismatch between AccessPolicy and accessPolicy"))
 	}
-	if reflect.TypeOf((*BlobPropertiesInternal)(nil)).Elem().Size() != reflect.TypeOf((*blobPropertiesInternal)(nil)).Elem().Size() {
+	if reflect.TypeOf((*BlobProperties)(nil)).Elem().Size() != reflect.TypeOf((*blobProperties)(nil)).Elem().Size() {
 		validateError(errors.New("size mismatch between BlobPropertiesInternal and blobPropertiesInternal"))
 	}
 	if reflect.TypeOf((*ContainerProperties)(nil)).Elem().Size() != reflect.TypeOf((*containerProperties)(nil)).Elem().Size() {
@@ -7589,7 +7589,7 @@ type accessPolicy struct {
 }
 
 // internal type used for marshalling
-type blobPropertiesInternal struct {
+type blobProperties struct {
 	// XMLName is used for marshalling and is subject to removal in a future release.
 	XMLName                   xml.Name              `xml:"Properties"`
 	CreationTime              *timeRFC1123          `xml:"Creation-Time"`


### PR DESCRIPTION
Reverting changes made to GetTags/SetTags in PutBlobFromUrl PR and changing BlobPropertiesInternal to BlobProperties to avoid breaking changes in AzCopy.