### PR TITLE
Fix ListContainers request on empty ListContainersDetail

### DIFF
--- a/azblob/url_service.go
+++ b/azblob/url_service.go
@@ -123,7 +123,10 @@ func (o *ListContainersSegmentOptions) pointers() (prefix *string, include []Lis
 	if o.MaxResults != 0 {
 		maxResults = &o.MaxResults
 	}
-	include = []ListContainersIncludeType{ListContainersIncludeType(o.Detail.string())}
+	details := o.Detail.string()
+	if len(details) > 0 {
+		include = []ListContainersIncludeType{ListContainersIncludeType(details)}
+	}
 	return
 }
 


### PR DESCRIPTION
Previous code was generating an invalid `include=""` parameter when provided `ListContainersDetail` was empty (zero value).

Sample code to reproduce the issue (using Azurite latest (3.13.1) dockerhub image - https://hub.docker.com/_/microsoft-azure-storage-azurite):
```go
resp, err := serviceURL.ListContainersSegment(
		context.Background(),
		azblob.Marker{},
		azblob.ListContainersSegmentOptions{}) // or even ListContainersSegmentOptions{Detail:azblob.ListContainersDetail{Metadata: false}}
if err != nil {
  log.Fatalf("Couldn't list containers: %s", err) // gives 400 bad request, GET http://127.0.0.1:10000/devstoreaccount1?comp=list&include=&timeout=61
}
```

Previous code was building the equivalent of a `[]ListContainersIncludeType{""}` (a slice of 1 string element with empty string as value), which is playing badly with the way `func (client serviceClient) listContainersSegmentPreparer(....)` is building that 'include' parameter: 

```go
// see zz_generated_service.go around lines 417++
func (client serviceClient) listContainersSegmentPreparer(...., include []ListContainersIncludeType, ...) {
[...]
  if include != nil && len(include) > 0 {
          // include query param is added as soon as we have a non-nil, non-empty slice.
          // in above case, it effectively do: params.Set("include",""), leading to invalid request for Azure/Azurite
	  params.Set("include", joinConst(include, ","))
  }
[...]
}
```