### PR TITLE
Clean up missed test containers

### DIFF
--- a/azblob/zt_blob_tags_test.go
+++ b/azblob/zt_blob_tags_test.go
@@ -6,12 +6,13 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"fmt"
-	chk "gopkg.in/check.v1"
 	"io/ioutil"
 	"log"
 	"net/url"
 	"strings"
 	"time"
+
+	chk "gopkg.in/check.v1"
 )
 
 func (s *aztestsSuite) TestSetBlobTags(c *chk.C) {
@@ -604,7 +605,7 @@ func (s *aztestsSuite) TestFilterBlobsUsingAccountSAS(c *chk.C) {
 	sasQueryParams, err := AccountSASSignatureValues{
 		Protocol:      SASProtocolHTTPS,
 		ExpiryTime:    time.Now().UTC().Add(48 * time.Hour),
-		Permissions:   AccountSASPermissions{Read: true, List: true, Write: true, DeletePreviousVersion: true, Tag: true, FilterByTags: true, Create: true}.String(),
+		Permissions:   AccountSASPermissions{Read: true, List: true, Write: true, DeletePreviousVersion: true, Tag: true, FilterByTags: true, Create: true, Delete: true}.String(),
 		Services:      AccountSASServices{Blob: true}.String(),
 		ResourceTypes: AccountSASResourceTypes{Service: true, Container: true, Object: true}.String(),
 	}.NewSASQueryParameters(credential)

--- a/azblob/zt_client_provided_key_test.go
+++ b/azblob/zt_client_provided_key_test.go
@@ -499,7 +499,7 @@ func (s *aztestsSuite) TestPageBlockWithCPK(c *chk.C) {
 func (s *aztestsSuite) TestPageBlockWithCPKByScope(c *chk.C) {
 	bsu := getBSU()
 	container, _ := createNewContainer(c, bsu)
-	// defer delContainer(c, container)
+	defer delContainer(c, container)
 
 	testSize := 1 * 1024 * 1024
 	r, srcData := getRandomDataAndReader(testSize)


### PR DESCRIPTION
- TestFilterBlobsUsingAccountSAS: The SAS token didn't have permission
  to delete containers. Add the permission to allow cleanup to succeed.
- TestPageBlockWithCPKByScope: The deferred cleanup was commented out,
  it's not clear why.