### PR TITLE
Return nil when blob tags map is empty

### DIFF
--- a/azblob/url_blob.go
+++ b/azblob/url_blob.go
@@ -2,10 +2,9 @@ package azblob
 
 import (
 	"context"
+	"github.com/Azure/azure-pipeline-go/pipeline"
 	"net/url"
 	"strings"
-
-	"github.com/Azure/azure-pipeline-go/pipeline"
 )
 
 // A BlobURL represents a URL to an Azure Storage blob; the blob may be a block blob, append blob, or page blob.

--- a/azblob/url_blob.go
+++ b/azblob/url_blob.go
@@ -2,9 +2,10 @@ package azblob
 
 import (
 	"context"
-	"github.com/Azure/azure-pipeline-go/pipeline"
 	"net/url"
 	"strings"
+
+	"github.com/Azure/azure-pipeline-go/pipeline"
 )
 
 // A BlobURL represents a URL to an Azure Storage blob; the blob may be a block blob, append blob, or page blob.
@@ -75,7 +76,7 @@ func (b BlobURL) ToPageBlobURL() PageBlobURL {
 }
 
 func SerializeBlobTagsHeader(blobTagsMap BlobTagsMap) *string {
-	if blobTagsMap == nil {
+	if blobTagsMap == nil || len(blobTagsMap) == 0 {
 		return nil
 	}
 	tags := make([]string, 0)

--- a/azblob/url_blob.go
+++ b/azblob/url_blob.go
@@ -2,9 +2,10 @@ package azblob
 
 import (
 	"context"
-	"github.com/Azure/azure-pipeline-go/pipeline"
 	"net/url"
 	"strings"
+
+	"github.com/Azure/azure-pipeline-go/pipeline"
 )
 
 // A BlobURL represents a URL to an Azure Storage blob; the blob may be a block blob, append blob, or page blob.
@@ -75,7 +76,7 @@ func (b BlobURL) ToPageBlobURL() PageBlobURL {
 }
 
 func SerializeBlobTagsHeader(blobTagsMap BlobTagsMap) *string {
-	if blobTagsMap == nil || len(blobTagsMap) == 0 {
+	if len(blobTagsMap) == 0 {
 		return nil
 	}
 	tags := make([]string, 0)
@@ -88,7 +89,7 @@ func SerializeBlobTagsHeader(blobTagsMap BlobTagsMap) *string {
 }
 
 func SerializeBlobTags(blobTagsMap BlobTagsMap) BlobTags {
-	if blobTagsMap == nil {
+	if len(blobTagsMap) == 0 {
 		return BlobTags{}
 	}
 	blobTagSet := make([]BlobTag, 0, len(blobTagsMap))


### PR DESCRIPTION
The `SerializeBlobTagsHeader` function checks if the provided map of tags is `nil` but not if it's _empty_. If the map is empty, the function will return a pointer to an empty string, causing `x-ms-tags` to be set with no elements. 

This change will have the function return `nil` if the length of the map is zero.